### PR TITLE
Bugfix: NPC spawner

### DIFF
--- a/Assets/Scripts/AbstractClasses/Movable.cs
+++ b/Assets/Scripts/AbstractClasses/Movable.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.AI;
 
 namespace AbstractClasses

--- a/Assets/Scripts/Entity/AttackLogic.cs
+++ b/Assets/Scripts/Entity/AttackLogic.cs
@@ -1,7 +1,4 @@
-﻿using Entity.Player;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using AbstractClasses;
 
 namespace Entity
@@ -37,7 +34,7 @@ namespace Entity
         private Movable _movable;
 
         private float _timer;
-        private GameObject _target;
+        private Damageable _target;
         private float _distanceToTarget;
 
         // ----temporary as animation replacement------
@@ -109,7 +106,7 @@ namespace Entity
         {
             _movable.StopMoving();
             // face target
-            if (_movable.FaceTarget(_target, true, out _))
+            if (_movable.FaceTarget(_target.gameObject, true, out _))
             {
                 // faces target
                 // perform hit
@@ -155,7 +152,7 @@ namespace Entity
         /// performs a hit on it and either resets or continues attacking.
         /// </summary>
         /// <param name="target">The target to be attacked</param>
-        public void StartAttack(GameObject target)
+        public void StartAttack(Damageable target)
         {
             print("start attack");
             _target = target;
@@ -185,12 +182,8 @@ namespace Entity
                 if (_distanceToTarget < attackRange)
                 {
                     // check rotation as well
-                    float difference;
-                    _movable.FaceTarget(_target, false, out difference);
-                    if (difference < hitRotationTolerance)
-                        return AttackStatus.Hit;
-                    else
-                        return AttackStatus.Miss;
+                    _movable.FaceTarget(_target.gameObject, false, out float difference);
+                    return difference < hitRotationTolerance ? AttackStatus.Hit : AttackStatus.Miss;
                 }
                 return AttackStatus.Miss;
             }

--- a/Assets/Scripts/Entity/Enemy/EnemyController.cs
+++ b/Assets/Scripts/Entity/Enemy/EnemyController.cs
@@ -1,7 +1,4 @@
 ﻿using AbstractClasses;
-using Managers;
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.AI;
 using Utils;
@@ -22,10 +19,6 @@ namespace Entity.Enemy
         [SerializeField]
         private bool freezeArea;
 
-        [Tooltip("The ground the NPC should walk on.")]
-        [SerializeField]
-        private LayerMask moveLayer;
-
         [Tooltip("The speed the NPC chases targets with.")]
         [SerializeField]
         private float runningSpeed;
@@ -33,10 +26,6 @@ namespace Entity.Enemy
         [Tooltip("Determine whether the NPC attacks and chases the player.")]
         [SerializeField]
         private bool isAggressive;
-
-        [Tooltip("The radius around the NPC in which a player gets the aggro.")]
-        [SerializeField]
-        private float lookRadius;
 
         [Tooltip("The radius around the NPC in which a player can escape.")]
         [SerializeField]
@@ -96,10 +85,10 @@ namespace Entity.Enemy
             if (!_isChasing)
                 Wander();
 
-            if (!isAggressive || targetFinder.Targets.Count == 0) return;
+            if (!isAggressive || !targetFinder.HasTarget()) return;
 
             // Attack first target in list
-            GameObject currentTarget = targetFinder.Targets[0];
+            Damageable currentTarget = targetFinder.GetFirstTarget();
 
             if (!_isChasing)
                 StartChasing(currentTarget);
@@ -128,7 +117,7 @@ namespace Entity.Enemy
         /// Starts attacking and chasing the target.
         /// </summary>
         /// <param name="target">The target to attack</param>
-        private void StartChasing(GameObject target)
+        private void StartChasing(Damageable target)
         {
             _isChasing = true;
             NavMeshAgent.speed = runningSpeed;
@@ -140,7 +129,7 @@ namespace Entity.Enemy
         /// </summary>
         private void StopChasing()
         {
-            targetFinder.Targets.RemoveAt(0);
+            targetFinder.RemoveFirstTarget();
             _isChasing = false;
             NavMeshAgent.speed = _initialSpeed;
             _attackLogic.StopAttack();
@@ -161,7 +150,7 @@ namespace Entity.Enemy
             else
             {
                 // don't use SetDestination but set calculated path
-                NavMeshPath wanderPath = _wanderAI.GetNextWanderPath(wanderArea, NavMeshAgent, moveLayer.value);
+                NavMeshPath wanderPath = _wanderAI.GetNextWanderPath(wanderArea, NavMeshAgent, NavMesh.AllAreas);
                 NavMeshAgent.SetPath(wanderPath);
                 NavMeshAgent.isStopped = false;
             }

--- a/Assets/Scripts/Entity/Enemy/TargetFinder.cs
+++ b/Assets/Scripts/Entity/Enemy/TargetFinder.cs
@@ -17,15 +17,32 @@ namespace Entity.Enemy
         /// <summary>
         /// List of all targets that entered the trigger-radius and have a layer of the <see cref="attackableLayers"/> layer mask
         /// </summary>
-        public readonly List<GameObject> Targets = new List<GameObject>();  //TODO: Should probably be replaced by the abstract class "Damageable"
+        private readonly List<Damageable> _targets = new List<Damageable>();
 
         private void OnTriggerEnter(Collider other)
         {
-            if(!attackableLayers.Contains(other.gameObject.layer)) return;
-            
-            if(other.gameObject.TryGetComponent(typeof(Damageable), out _))
-                if(!Targets.Contains(other.gameObject))
-                    Targets.Add(other.gameObject);
+            if (!attackableLayers.Contains(other.gameObject.layer)) return;
+
+            if (other.gameObject.TryGetComponent(out Damageable target))
+                if (!_targets.Contains(target))
+                    _targets.Add(target);
         }
+
+        /// <summary>
+        /// Checks if the target finder has found any targets.
+        /// </summary>
+        /// <returns>True if at least one target was found, otherwise false</returns>
+        public bool HasTarget() => _targets.Count > 0;
+
+        /// <summary>
+        /// Gets the first target from the target finder.
+        /// </summary>
+        /// <returns>The first target from the list of targets, or null if the list doesn't contain any targets</returns>
+        public Damageable GetFirstTarget() => HasTarget() ? _targets[0] : null;
+
+        /// <summary>
+        /// Removes the first target from the target finder.
+        /// </summary>
+        public void RemoveFirstTarget() => _targets.RemoveAt(0);
     }
 }

--- a/Assets/Scripts/Entity/Enemy/WanderAI.cs
+++ b/Assets/Scripts/Entity/Enemy/WanderAI.cs
@@ -1,8 +1,4 @@
-﻿using Constants;
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.AI;
 using Utils;
 
@@ -24,14 +20,14 @@ namespace Entity.Enemy
         /// </summary>
         /// <param name="wanderArea">The area to generate the path in</param>
         /// <param name="agent">The agent of the NPC to generate the path for</param>
-        /// <param name="layermask">The ground</param>
+        /// <param name="areaMask">The NavMesh area the entity is allowed to move in</param>
         /// <returns>The next wander path</returns>
-        public NavMeshPath GetNextWanderPath(Area wanderArea, NavMeshAgent agent, int layermask)
+        public NavMeshPath GetNextWanderPath(Area wanderArea, NavMeshAgent agent, int areaMask)
         {
             NavMeshPath path = new NavMeshPath();
             do
             {
-                Vector3 wanderPoint = _navMeshMapper.GetMappedRandomPoint(wanderArea, layermask);
+                Vector3 wanderPoint = _navMeshMapper.GetMappedRandomPoint(wanderArea, areaMask);
                 agent.CalculatePath(wanderPoint, path);
             }
             while (!IsPathInArea(wanderArea, path));

--- a/Assets/Scripts/Entity/Player/PlayerController.cs
+++ b/Assets/Scripts/Entity/Player/PlayerController.cs
@@ -144,38 +144,36 @@ namespace Entity.Player
         {
             if (EventSystem.current.IsPointerOverGameObject())
                 return;
-            else
+            
+            Ray clickRay = _camera.ScreenPointToRay(Mouse.current.position.ReadValue());
+
+            // only change target / move, if not performing a hit
+            if (Physics.Raycast(clickRay, out RaycastHit hit, 10000, clickableLayers) &&
+                _attackLogic.Status == AttackLogic.AttackStatus.None)
             {
-                Ray clickRay = _camera.ScreenPointToRay(Mouse.current.position.ReadValue());
+                GameObject objectHit = hit.collider.gameObject;
 
-                // only change target / move, if not performing a hit
-                if (Physics.Raycast(clickRay, out RaycastHit hit, 10000, clickableLayers) &&
-                    _attackLogic.Status == AttackLogic.AttackStatus.None)
+                if (objectHit.GetComponent<Damageable>() is Damageable damageable)
                 {
-                    GameObject objectHit = hit.collider.gameObject;
+                    _interactLogic.RemoveFocus();
+                    // implementation NOT capable of area damage
+                    _attackLogic.StartAttack(damageable);
+                }
 
-                    if (objectHit.GetComponent<Damageable>() is Damageable damageable)
-                    {
-                        _interactLogic.RemoveFocus();
-                        // implementation NOT capable of area damage
-                        _attackLogic.StartAttack(objectHit);
-                    }
+                else if (objectHit.GetComponent<Interactable>() is Interactable interactable)
+                {
+                    _attackLogic.StopAttack();
+                    //Set as focus
+                    _interactLogic.StartInteract(interactable);
+                }
 
-                    else if (objectHit.GetComponent<Interactable>() is Interactable interactable)
-                    {
-                        _attackLogic.StopAttack();
-                        //Set as focus
-                        _interactLogic.StartInteract(interactable);
-                    }
-
-                    // Get ground position from mouse click
-                    else if (Physics.Raycast(clickRay, out RaycastHit groundHit, 10000, groundLayer))
-                    {
-                        // cancel possible ongoing attacks
-                        _attackLogic.StopAttack();
-                        _interactLogic.RemoveFocus();
-                        Move(groundHit);
-                    }
+                // Get ground position from mouse click
+                else if (Physics.Raycast(clickRay, out RaycastHit groundHit, 10000, groundLayer))
+                {
+                    // cancel possible ongoing attacks
+                    _attackLogic.StopAttack();
+                    _interactLogic.RemoveFocus();
+                    Move(groundHit);
                 }
             }
         }
@@ -200,11 +198,9 @@ namespace Entity.Player
         {
             if (EventSystem.current.IsPointerOverGameObject())
                 return;
-            else
-            {
-                _cameraAngleX += obj.ReadValue<float>() * cameraRotationSpeed * (invertRotation ? -1 : 1);
-                UpdateCameraAngle();
-            }
+            
+            _cameraAngleX += obj.ReadValue<float>() * cameraRotationSpeed * (invertRotation ? -1 : 1);
+            UpdateCameraAngle();
         }
 
         /// <summary>

--- a/Assets/Scripts/Entity/Player/PlayerController.cs
+++ b/Assets/Scripts/Entity/Player/PlayerController.cs
@@ -153,14 +153,14 @@ namespace Entity.Player
             {
                 GameObject objectHit = hit.collider.gameObject;
 
-                if (objectHit.GetComponent<Damageable>() is Damageable damageable)
+                if (objectHit.TryGetComponent(out Damageable damageable))
                 {
                     _interactLogic.RemoveFocus();
                     // implementation NOT capable of area damage
                     _attackLogic.StartAttack(damageable);
                 }
 
-                else if (objectHit.GetComponent<Interactable>() is Interactable interactable)
+                else if (objectHit.TryGetComponent(out Interactable interactable))
                 {
                     _attackLogic.StopAttack();
                     //Set as focus

--- a/Assets/Scripts/Spawner/NPCSpawner.cs
+++ b/Assets/Scripts/Spawner/NPCSpawner.cs
@@ -1,7 +1,4 @@
-﻿using Constants;
-using Entity.Enemy;
-using System;
-using System.Collections;
+﻿using Entity.Enemy;
 using UnityEngine;
 using UnityEngine.AI;
 using Utils;
@@ -26,10 +23,6 @@ namespace Spawner
         [Tooltip("The NPC to spawn")]
         [SerializeField]
         private EnemyController toSpawn;
-
-        [Tooltip("The ground to spawn NPCs on")]
-        [SerializeField]
-        private LayerMask spawnLayer;
 
         [Tooltip("The main camera")]
         [SerializeField]
@@ -75,7 +68,7 @@ namespace Spawner
         /// </summary>
         private void TrySpawn()
         {
-            Vector3 spawnLocation = _navMeshMapper.GetMappedRandomPoint(spawnArea, spawnLayer.value);
+            Vector3 spawnLocation = _navMeshMapper.GetMappedRandomPoint(spawnArea, NavMesh.AllAreas);
             // setting a random rotation doesn't seem to work with a NavMeshAgent, but since NPCs start walking in a random direction immediately it doesn't really matter
             EnemyController spawned = Instantiate(toSpawn, spawnLocation, Quaternion.identity, transform);
             Renderer renderer = spawned.Renderer;

--- a/Assets/Scripts/Utils/NavMeshMapper.cs
+++ b/Assets/Scripts/Utils/NavMeshMapper.cs
@@ -11,21 +11,21 @@ namespace Utils
     public class NavMeshMapper
     {
         /// <summary>
-        /// Returns a random point mapped onto the layermask.
+        /// Returns a random point mapped onto the NavMesh.
         /// Since NavMesh.SamplePosition() can get very expensive, it's better to use it with a small distance
         /// and try multiple times (and only use the random points that are near the NavMesh).
         /// </summary>
         /// <param name="area">The area to draw the point from</param>
-        /// <param name="layermask">The layermask to map the point onto</param>
+        /// <param name="areaMask">The NavMesh area mask to map the point onto</param>
         /// <returns>The random point on the ground</returns>
-        public Vector3 GetMappedRandomPoint(Area area, int layermask)
+        public Vector3 GetMappedRandomPoint(Area area, int areaMask)
         {
             for (int i = 0; i < Consts.Utils.MAPPING_ITERATIONS; i++)
             {
                 Vector3 randomPoint = GetRandomPoint(area);
                 // try to map point onto NavMesh
                 NavMeshHit hit;
-                if (NavMesh.SamplePosition(randomPoint, out hit, Consts.Utils.MAX_NAVMESH_MAPPING_DISTANCE, layermask))
+                if (NavMesh.SamplePosition(randomPoint, out hit, Consts.Utils.MAX_NAVMESH_MAPPING_DISTANCE, areaMask))
                 {
                     return hit.position;
                 }

--- a/Assets/Scripts/Utils/NavMeshMapper.cs
+++ b/Assets/Scripts/Utils/NavMeshMapper.cs
@@ -24,8 +24,7 @@ namespace Utils
             {
                 Vector3 randomPoint = GetRandomPoint(area);
                 // try to map point onto NavMesh
-                NavMeshHit hit;
-                if (NavMesh.SamplePosition(randomPoint, out hit, Consts.Utils.MAX_NAVMESH_MAPPING_DISTANCE, areaMask))
+                if (NavMesh.SamplePosition(randomPoint, out NavMeshHit hit, Consts.Utils.MAX_NAVMESH_MAPPING_DISTANCE, areaMask))
                 {
                     return hit.position;
                 }

--- a/InSaneSurvival.sln.DotSettings
+++ b/InSaneSurvival.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AI/@EntryIndexedValue">AI</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NPC/@EntryIndexedValue">NPC</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=equipable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Interactable/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Removed layer mask field from spawner, since the nav mesh mapping function doesn't require a layer mask, but an area mask for the nav mesh instead. Sadly, Unity doesn't provide a class for this, so we would need to write our own inspector for this to work properly. But since I don't think that we need this anytime soon, I've just removed it for now.