### PR TITLE
Death scene update

### DIFF
--- a/Assets/Prefabs/Entities/Bear.prefab
+++ b/Assets/Prefabs/Entities/Bear.prefab
@@ -86,7 +86,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: aaa35902a700a3c4fa0f8326cfd2b2f0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  damage: 2
+  damage: 10
   attackRange: 3.7
   attackTime: 1.2
   hitRotationTolerance: 30
@@ -402,6 +402,250 @@ PrefabInstance:
       propertyPath: m_Name
       value: Graphics
       objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -89.98021
+      objectReference: {fileID: 0}
+    - target: {fileID: 400002, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0.0000040882387
+      objectReference: {fileID: 0}
+    - target: {fileID: 400002, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 1.2185461e-14
+      objectReference: {fileID: 0}
+    - target: {fileID: 400002, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -1.21854626e-14
+      objectReference: {fileID: 0}
+    - target: {fileID: 400006, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -45.150185
+      objectReference: {fileID: 0}
+    - target: {fileID: 400006, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -110.03779
+      objectReference: {fileID: 0}
+    - target: {fileID: 400006, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 166.1738
+      objectReference: {fileID: 0}
+    - target: {fileID: 400010, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 2.511567
+      objectReference: {fileID: 0}
+    - target: {fileID: 400010, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -138.45583
+      objectReference: {fileID: 0}
+    - target: {fileID: 400010, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 133.273
+      objectReference: {fileID: 0}
+    - target: {fileID: 400014, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -81.83201
+      objectReference: {fileID: 0}
+    - target: {fileID: 400014, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -17.82379
+      objectReference: {fileID: 0}
+    - target: {fileID: 400014, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 9.55266
+      objectReference: {fileID: 0}
+    - target: {fileID: 400016, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -54.790924
+      objectReference: {fileID: 0}
+    - target: {fileID: 400016, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -179.99998
+      objectReference: {fileID: 0}
+    - target: {fileID: 400016, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 179.99998
+      objectReference: {fileID: 0}
+    - target: {fileID: 400018, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -33.313805
+      objectReference: {fileID: 0}
+    - target: {fileID: 400018, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.59873027
+      objectReference: {fileID: 0}
+    - target: {fileID: 400018, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -17.92724
+      objectReference: {fileID: 0}
+    - target: {fileID: 400022, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -41.945908
+      objectReference: {fileID: 0}
+    - target: {fileID: 400022, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.6726218
+      objectReference: {fileID: 0}
+    - target: {fileID: 400022, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 18.705719
+      objectReference: {fileID: 0}
+    - target: {fileID: 400026, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -24.156677
+      objectReference: {fileID: 0}
+    - target: {fileID: 400026, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -179.99998
+      objectReference: {fileID: 0}
+    - target: {fileID: 400026, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 179.99998
+      objectReference: {fileID: 0}
+    - target: {fileID: 400028, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -88.23408
+      objectReference: {fileID: 0}
+    - target: {fileID: 400028, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -179.9997
+      objectReference: {fileID: 0}
+    - target: {fileID: 400028, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 179.9997
+      objectReference: {fileID: 0}
+    - target: {fileID: 400030, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -19.398191
+      objectReference: {fileID: 0}
+    - target: {fileID: 400030, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0.000001501365
+      objectReference: {fileID: 0}
+    - target: {fileID: 400030, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0.0000025554382
+      objectReference: {fileID: 0}
+    - target: {fileID: 400034, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -78.25589
+      objectReference: {fileID: 0}
+    - target: {fileID: 400034, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.00002409324
+      objectReference: {fileID: 0}
+    - target: {fileID: 400034, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0.00003286328
+      objectReference: {fileID: 0}
+    - target: {fileID: 400038, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -19.632631
+      objectReference: {fileID: 0}
+    - target: {fileID: 400038, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.0000006630319
+      objectReference: {fileID: 0}
+    - target: {fileID: 400038, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0.0000026151013
+      objectReference: {fileID: 0}
+    - target: {fileID: 400040, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 24.168161
+      objectReference: {fileID: 0}
+    - target: {fileID: 400040, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 62.96374
+      objectReference: {fileID: 0}
+    - target: {fileID: 400040, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 62.9105
+      objectReference: {fileID: 0}
+    - target: {fileID: 400042, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 28.486614
+      objectReference: {fileID: 0}
+    - target: {fileID: 400042, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 108.72874
+      objectReference: {fileID: 0}
+    - target: {fileID: 400042, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 109.88788
+      objectReference: {fileID: 0}
+    - target: {fileID: 400044, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -57.05149
+      objectReference: {fileID: 0}
+    - target: {fileID: 400044, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -28.336693
+      objectReference: {fileID: 0}
+    - target: {fileID: 400044, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -42.966125
+      objectReference: {fileID: 0}
+    - target: {fileID: 400048, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -29.386333
+      objectReference: {fileID: 0}
+    - target: {fileID: 400048, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -63.290394
+      objectReference: {fileID: 0}
+    - target: {fileID: 400048, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 24.847393
+      objectReference: {fileID: 0}
+    - target: {fileID: 400052, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -81.335434
+      objectReference: {fileID: 0}
+    - target: {fileID: 400052, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 175.89874
+      objectReference: {fileID: 0}
+    - target: {fileID: 400052, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -168.15846
+      objectReference: {fileID: 0}
+    - target: {fileID: 400054, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -50.70978
+      objectReference: {fileID: 0}
+    - target: {fileID: 400054, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.32641554
+      objectReference: {fileID: 0}
+    - target: {fileID: 400054, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -13.507229
+      objectReference: {fileID: 0}
+    - target: {fileID: 400056, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 41.852234
+      objectReference: {fileID: 0}
+    - target: {fileID: 400056, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -8.722325
+      objectReference: {fileID: 0}
+    - target: {fileID: 400056, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -12.350715
+      objectReference: {fileID: 0}
+    - target: {fileID: 400060, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 53.79749
+      objectReference: {fileID: 0}
+    - target: {fileID: 400060, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 8.087522
+      objectReference: {fileID: 0}
+    - target: {fileID: 400060, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 10.876393
+      objectReference: {fileID: 0}
     - target: {fileID: 400064, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -458,273 +702,17 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 1.5
       objectReference: {fileID: 0}
-    - target: {fileID: 9500000, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 9100000, guid: 6731441f7e464422baf7f811d2ddf7de, type: 2}
-    - target: {fileID: 400000, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+    - target: {fileID: 400066, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -89.98021
+      value: 16.578444
       objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.0000040882387
-      objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+    - target: {fileID: 400066, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 1.2185461e-14
+      value: -0.000011037408
       objectReference: {fileID: 0}
-    - target: {fileID: 400002, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+    - target: {fileID: 400066, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: -1.21854626e-14
-      objectReference: {fileID: 0}
-    - target: {fileID: 400014, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -81.83201
-      objectReference: {fileID: 0}
-    - target: {fileID: 400014, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -17.82379
-      objectReference: {fileID: 0}
-    - target: {fileID: 400014, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 9.55266
-      objectReference: {fileID: 0}
-    - target: {fileID: 400026, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -24.156677
-      objectReference: {fileID: 0}
-    - target: {fileID: 400026, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -179.99998
-      objectReference: {fileID: 0}
-    - target: {fileID: 400026, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 179.99998
-      objectReference: {fileID: 0}
-    - target: {fileID: 400028, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -88.23408
-      objectReference: {fileID: 0}
-    - target: {fileID: 400028, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -179.9997
-      objectReference: {fileID: 0}
-    - target: {fileID: 400028, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 179.9997
-      objectReference: {fileID: 0}
-    - target: {fileID: 400016, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -54.790924
-      objectReference: {fileID: 0}
-    - target: {fileID: 400016, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -179.99998
-      objectReference: {fileID: 0}
-    - target: {fileID: 400016, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 179.99998
-      objectReference: {fileID: 0}
-    - target: {fileID: 400072, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -89.98021
-      objectReference: {fileID: 0}
-    - target: {fileID: 400072, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -179.99998
-      objectReference: {fileID: 0}
-    - target: {fileID: 400034, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -78.25589
-      objectReference: {fileID: 0}
-    - target: {fileID: 400034, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.00002409324
-      objectReference: {fileID: 0}
-    - target: {fileID: 400034, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.00003286328
-      objectReference: {fileID: 0}
-    - target: {fileID: 400030, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -19.398191
-      objectReference: {fileID: 0}
-    - target: {fileID: 400030, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0.000001501365
-      objectReference: {fileID: 0}
-    - target: {fileID: 400030, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.0000025554382
-      objectReference: {fileID: 0}
-    - target: {fileID: 400018, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -33.313805
-      objectReference: {fileID: 0}
-    - target: {fileID: 400018, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.59873027
-      objectReference: {fileID: 0}
-    - target: {fileID: 400018, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -17.92724
-      objectReference: {fileID: 0}
-    - target: {fileID: 400022, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -41.945908
-      objectReference: {fileID: 0}
-    - target: {fileID: 400022, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.6726218
-      objectReference: {fileID: 0}
-    - target: {fileID: 400022, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 18.705719
-      objectReference: {fileID: 0}
-    - target: {fileID: 400074, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 84.82956
-      objectReference: {fileID: 0}
-    - target: {fileID: 400074, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -120.77071
-      objectReference: {fileID: 0}
-    - target: {fileID: 400074, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 59.331768
-      objectReference: {fileID: 0}
-    - target: {fileID: 400080, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -68.6756
-      objectReference: {fileID: 0}
-    - target: {fileID: 400080, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 6.710345
-      objectReference: {fileID: 0}
-    - target: {fileID: 400080, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 179.9997
-      objectReference: {fileID: 0}
-    - target: {fileID: 400076, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 5.8510227
-      objectReference: {fileID: 0}
-    - target: {fileID: 400076, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.000013777514
-      objectReference: {fileID: 0}
-    - target: {fileID: 400076, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -0.0000012757664
-      objectReference: {fileID: 0}
-    - target: {fileID: 400082, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -10.685418
-      objectReference: {fileID: 0}
-    - target: {fileID: 400082, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.0000066366592
-      objectReference: {fileID: 0}
-    - target: {fileID: 400082, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -0.0000014639792
-      objectReference: {fileID: 0}
-    - target: {fileID: 400052, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -81.335434
-      objectReference: {fileID: 0}
-    - target: {fileID: 400052, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 175.89874
-      objectReference: {fileID: 0}
-    - target: {fileID: 400052, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -168.15846
-      objectReference: {fileID: 0}
-    - target: {fileID: 400054, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -50.70978
-      objectReference: {fileID: 0}
-    - target: {fileID: 400054, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.32641554
-      objectReference: {fileID: 0}
-    - target: {fileID: 400054, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -13.507229
-      objectReference: {fileID: 0}
-    - target: {fileID: 400078, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 14.2113695
-      objectReference: {fileID: 0}
-    - target: {fileID: 400078, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0.0000016535744
-      objectReference: {fileID: 0}
-    - target: {fileID: 400078, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -0.0000028416225
-      objectReference: {fileID: 0}
-    - target: {fileID: 400084, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -9.607961
-      objectReference: {fileID: 0}
-    - target: {fileID: 400084, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0.00000016865336
-      objectReference: {fileID: 0}
-    - target: {fileID: 400084, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -0.0000019147747
-      objectReference: {fileID: 0}
-    - target: {fileID: 400040, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 24.168161
-      objectReference: {fileID: 0}
-    - target: {fileID: 400040, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 62.96374
-      objectReference: {fileID: 0}
-    - target: {fileID: 400040, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 62.9105
-      objectReference: {fileID: 0}
-    - target: {fileID: 400042, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 28.486614
-      objectReference: {fileID: 0}
-    - target: {fileID: 400042, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 108.72874
-      objectReference: {fileID: 0}
-    - target: {fileID: 400042, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 109.88788
-      objectReference: {fileID: 0}
-    - target: {fileID: 400056, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 41.852234
-      objectReference: {fileID: 0}
-    - target: {fileID: 400056, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -8.722325
-      objectReference: {fileID: 0}
-    - target: {fileID: 400056, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -12.350715
-      objectReference: {fileID: 0}
-    - target: {fileID: 400060, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 53.79749
-      objectReference: {fileID: 0}
-    - target: {fileID: 400060, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 8.087522
-      objectReference: {fileID: 0}
-    - target: {fileID: 400060, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 10.876393
+      value: -0.0000051365173
       objectReference: {fileID: 0}
     - target: {fileID: 400070, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -738,6 +726,86 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -0.62559944
       objectReference: {fileID: 0}
+    - target: {fileID: 400072, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -89.98021
+      objectReference: {fileID: 0}
+    - target: {fileID: 400072, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -179.99998
+      objectReference: {fileID: 0}
+    - target: {fileID: 400074, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 84.82956
+      objectReference: {fileID: 0}
+    - target: {fileID: 400074, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -120.77071
+      objectReference: {fileID: 0}
+    - target: {fileID: 400074, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 59.331768
+      objectReference: {fileID: 0}
+    - target: {fileID: 400076, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 5.8510227
+      objectReference: {fileID: 0}
+    - target: {fileID: 400076, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.000013777514
+      objectReference: {fileID: 0}
+    - target: {fileID: 400076, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -0.0000012757664
+      objectReference: {fileID: 0}
+    - target: {fileID: 400078, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 14.2113695
+      objectReference: {fileID: 0}
+    - target: {fileID: 400078, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0.0000016535744
+      objectReference: {fileID: 0}
+    - target: {fileID: 400078, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -0.0000028416225
+      objectReference: {fileID: 0}
+    - target: {fileID: 400080, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -68.6756
+      objectReference: {fileID: 0}
+    - target: {fileID: 400080, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 6.710345
+      objectReference: {fileID: 0}
+    - target: {fileID: 400080, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 179.9997
+      objectReference: {fileID: 0}
+    - target: {fileID: 400082, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -10.685418
+      objectReference: {fileID: 0}
+    - target: {fileID: 400082, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.0000066366592
+      objectReference: {fileID: 0}
+    - target: {fileID: 400082, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -0.0000014639792
+      objectReference: {fileID: 0}
+    - target: {fileID: 400084, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -9.607961
+      objectReference: {fileID: 0}
+    - target: {fileID: 400084, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0.00000016865336
+      objectReference: {fileID: 0}
+    - target: {fileID: 400084, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -0.0000019147747
+      objectReference: {fileID: 0}
     - target: {fileID: 400086, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: -21.288683
@@ -749,42 +817,6 @@ PrefabInstance:
     - target: {fileID: 400086, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: -0.0000018368573
-      objectReference: {fileID: 0}
-    - target: {fileID: 400044, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -57.05149
-      objectReference: {fileID: 0}
-    - target: {fileID: 400044, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -28.336693
-      objectReference: {fileID: 0}
-    - target: {fileID: 400044, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -42.966125
-      objectReference: {fileID: 0}
-    - target: {fileID: 400038, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -19.632631
-      objectReference: {fileID: 0}
-    - target: {fileID: 400038, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.0000006630319
-      objectReference: {fileID: 0}
-    - target: {fileID: 400038, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.0000026151013
-      objectReference: {fileID: 0}
-    - target: {fileID: 400048, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -29.386333
-      objectReference: {fileID: 0}
-    - target: {fileID: 400048, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -63.290394
-      objectReference: {fileID: 0}
-    - target: {fileID: 400048, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 24.847393
       objectReference: {fileID: 0}
     - target: {fileID: 400088, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -798,42 +830,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0.0000002837038
       objectReference: {fileID: 0}
-    - target: {fileID: 400010, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 2.511567
-      objectReference: {fileID: 0}
-    - target: {fileID: 400010, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -138.45583
-      objectReference: {fileID: 0}
-    - target: {fileID: 400010, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 133.273
-      objectReference: {fileID: 0}
-    - target: {fileID: 400006, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -45.150185
-      objectReference: {fileID: 0}
-    - target: {fileID: 400006, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -110.03779
-      objectReference: {fileID: 0}
-    - target: {fileID: 400006, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 166.1738
-      objectReference: {fileID: 0}
-    - target: {fileID: 400066, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 16.578444
-      objectReference: {fileID: 0}
-    - target: {fileID: 400066, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.000011037408
-      objectReference: {fileID: 0}
-    - target: {fileID: 400066, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -0.0000051365173
-      objectReference: {fileID: 0}
+    - target: {fileID: 9500000, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: 6731441f7e464422baf7f811d2ddf7de, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 27288711b766645469e4ece2fe1caffd, type: 3}
 --- !u!1 &8351342211080596169 stripped

--- a/Assets/Prefabs/Entities/PlayerDeathScene.prefab
+++ b/Assets/Prefabs/Entities/PlayerDeathScene.prefab
@@ -1,0 +1,226 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!82 &4001791009992417591
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1087349226835474499}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0.039
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!114 &7213476324555889322
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1087349226835474499}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1666e29586194b6b9c4dc15dff02b1a7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1424811160435630780
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5904312009668761741}
+  m_Layer: 0
+  m_Name: PlayerDeathScene
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5904312009668761741
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1424811160435630780}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 6.4575415, y: 9.433847, z: -18.595013}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1087349226835633187}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1087349226835508893
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 5904312009668761741}
+    m_Modifications:
+    - target: {fileID: 100062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_Name
+      value: Graphics
+      objectReference: {fileID: 0}
+    - target: {fileID: 9500000, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: aa92fea03dfbd4862bdc076cb9438978, type: 2}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -6.4575415
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -9.433847
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.750988
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.8821009
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.8821
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.8821009
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+--- !u!1 &1087349226835474499 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 100062, guid: ae495434e84223e4986a98db34c5941a,
+    type: 3}
+  m_PrefabInstance: {fileID: 1087349226835508893}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1087349226835633187 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a,
+    type: 3}
+  m_PrefabInstance: {fileID: 1087349226835508893}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Entities/PlayerDeathScene.prefab.meta
+++ b/Assets/Prefabs/Entities/PlayerDeathScene.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: decadfc27aec3c9478b0f0120832b406
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Managers/AudioManager.prefab
+++ b/Assets/Prefabs/Managers/AudioManager.prefab
@@ -29,7 +29,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2485922283269177303}
-  - {fileID: 333071784540420752}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -45,55 +44,38 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 38b0f5a87e65247f1a476fda246ab24b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  sounds: []
+  sounds:
+  - name: uiClick
+    clip: {fileID: 8300000, guid: a9407594401e72b45a847693d0d39351, type: 3}
+    volume: 1
+    loop: 0
+    source: {fileID: 0}
+  - name: uiHover
+    clip: {fileID: 8300000, guid: 2ba5b4a3d479ec6468afd790ca50af81, type: 3}
+    volume: 1
+    loop: 0
+    source: {fileID: 0}
+  - name: musicTheme
+    clip: {fileID: 8300000, guid: 5db8a52c87ea4df48854ba8fb4cd464a, type: 3}
+    volume: 0.2
+    loop: 1
+    source: {fileID: 0}
+  - name: ambBirds
+    clip: {fileID: 8300000, guid: 55b3948d57f934b41ba067f1b72b858f, type: 3}
+    volume: 0.2
+    loop: 1
+    source: {fileID: 0}
+  - name: ambCrickets
+    clip: {fileID: 8300000, guid: 8d1fab9002809b24db2093808ec4382b, type: 3}
+    volume: 0.2
+    loop: 1
+    source: {fileID: 0}
+  - name: ambOwl
+    clip: {fileID: 8300000, guid: 339091a2c7883a64ab8c5b59625522da, type: 3}
+    volume: 0.5
+    loop: 1
+    source: {fileID: 0}
   audioSources: {fileID: 0}
---- !u!1 &4911869876185031915
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 333071784540420752}
-  - component: {fileID: 8302764615109661774}
-  m_Layer: 0
-  m_Name: Ambience
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &333071784540420752
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4911869876185031915}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 5719382801887882737}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &8302764615109661774
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4911869876185031915}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2e5ceaa12d6ee044aa4961ba1a04570c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  clock: {fileID: 0}
-  dayTimeAmbience: 
-  nightTimeAmbience: 
-  moonLightAmbience: 
 --- !u!1 &7058954467443417514
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/ScenePrefabs/=====_ Managers.prefab
+++ b/Assets/Prefabs/ScenePrefabs/=====_ Managers.prefab
@@ -31,7 +31,6 @@ Transform:
   - {fileID: 523893637789143666}
   - {fileID: 7362153649542830066}
   - {fileID: 8331599530203351898}
-  - {fileID: 6260835071504314523}
   - {fileID: 1591728970454311572}
   - {fileID: 5927897195196016188}
   - {fileID: 7209149007321884530}
@@ -89,7 +88,7 @@ PrefabInstance:
     - target: {fileID: 7052525062765905006, guid: 8abbb179f71a7944aa2c5e4b2bc8e97b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 7052525062765905006, guid: 8abbb179f71a7944aa2c5e4b2bc8e97b,
         type: 3}
@@ -184,7 +183,7 @@ PrefabInstance:
     - target: {fileID: 5139808686155900753, guid: 07d86147cfe4a72429218e9c926f99e7,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 5139808686155900753, guid: 07d86147cfe4a72429218e9c926f99e7,
         type: 3}
@@ -208,81 +207,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 5139808686155900753, guid: 07d86147cfe4a72429218e9c926f99e7,
     type: 3}
   m_PrefabInstance: {fileID: 1517814039969481069}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1854814580238392682
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1854814581397351230}
-    m_Modifications:
-    - target: {fileID: 2415918641645154796, guid: b5564caf433bd44caa131a7593260484,
-        type: 3}
-      propertyPath: m_Name
-      value: AudioManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 40.940826
-      objectReference: {fileID: 0}
-    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -172.45729
-      objectReference: {fileID: 0}
-    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 13.45224
-      objectReference: {fileID: 0}
-    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: b5564caf433bd44caa131a7593260484, type: 3}
---- !u!4 &6260835071504314523 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
-    type: 3}
-  m_PrefabInstance: {fileID: 1854814580238392682}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1854814580248824728
 PrefabInstance:
@@ -547,10 +471,15 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1854814581397351230}
     m_Modifications:
+    - target: {fileID: 3571764818514977077, guid: cb4d93f5bbb06254387a6696c85d4d76,
+        type: 3}
+      propertyPath: m_Name
+      value: DayNightManager
+      objectReference: {fileID: 0}
     - target: {fileID: 3571764818514977079, guid: cb4d93f5bbb06254387a6696c85d4d76,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 3571764818514977079, guid: cb4d93f5bbb06254387a6696c85d4d76,
         type: 3}
@@ -581,11 +510,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3571764818514977077, guid: cb4d93f5bbb06254387a6696c85d4d76,
-        type: 3}
-      propertyPath: m_Name
-      value: DayNightManager
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cb4d93f5bbb06254387a6696c85d4d76, type: 3}
@@ -725,7 +649,7 @@ PrefabInstance:
     - target: {fileID: 6003750396554747860, guid: ac9a21b2fbaebf14188115954389de9f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 6003750396554747860, guid: ac9a21b2fbaebf14188115954389de9f,
         type: 3}

--- a/Assets/Prefabs/UI/DeathMenu.prefab
+++ b/Assets/Prefabs/UI/DeathMenu.prefab
@@ -166,6 +166,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2472492525004171316}
   - component: {fileID: 5848118785574363514}
+  - component: {fileID: 8211705799578569536}
   m_Layer: 5
   m_Name: DeathMenu
   m_TagString: Untagged
@@ -206,6 +207,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mainMenuButton: {fileID: 1864854612316470025}
+--- !u!114 &8211705799578569536
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2472492525004171323}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79fb94aaa047b9b40ba2705fe820f81c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  btnHoverSound: 
+  btnClickSound: 
 --- !u!1 &2472492525262297408
 GameObject:
   m_ObjectHideFlags: 0
@@ -548,6 +563,7 @@ GameObject:
   - component: {fileID: 7964901276067708966}
   - component: {fileID: 7307795879217515016}
   - component: {fileID: 1864854612316470025}
+  - component: {fileID: 1311843366758528093}
   m_Layer: 5
   m_Name: btn_menu
   m_TagString: Untagged
@@ -654,3 +670,46 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &1311843366758528093
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6935892264420744417}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 0
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 8211705799578569536}
+          m_MethodName: PlayOnHover
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - eventID: 2
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 8211705799578569536}
+          m_MethodName: PlayOnClick
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2

--- a/Assets/Scenes/DeathScene.unity
+++ b/Assets/Scenes/DeathScene.unity
@@ -120,1475 +120,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &227121202 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1555847620765010, guid: 54f08473df2a94348a95272458da3885,
-    type: 3}
-  m_PrefabInstance: {fileID: 482033825}
-  m_PrefabAsset: {fileID: 0}
---- !u!95 &227121208 stripped
-Animator:
-  m_CorrespondingSourceObject: {fileID: 95857483032514940, guid: 54f08473df2a94348a95272458da3885,
-    type: 3}
-  m_PrefabInstance: {fileID: 482033825}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &482033825
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1555847620765010, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_Name
-      value: Wolf_wander
-      objectReference: {fileID: 0}
-    - target: {fileID: 4092247331235762, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.001
-      objectReference: {fileID: 0}
-    - target: {fileID: 4092247331235762, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 8.2105445e-17
-      objectReference: {fileID: 0}
-    - target: {fileID: 4092247331235762, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -19.355
-      objectReference: {fileID: 0}
-    - target: {fileID: 4092247331235762, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4092247331235762, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 4092247331235762, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4092247331235762, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 4092247331235762, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 4092247331235762, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4092247331235762, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 4092247331235762, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4024085787032988, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 19.6025
-      objectReference: {fileID: 0}
-    - target: {fileID: 4024085787032988, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -30.432484
-      objectReference: {fileID: 0}
-    - target: {fileID: 4024085787032988, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -82.553024
-      objectReference: {fileID: 0}
-    - target: {fileID: 4919666325982460, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 40.314266
-      objectReference: {fileID: 0}
-    - target: {fileID: 4919666325982460, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -11.883358
-      objectReference: {fileID: 0}
-    - target: {fileID: 4919666325982460, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -73.352295
-      objectReference: {fileID: 0}
-    - target: {fileID: 4904982257206242, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -3.0071566
-      objectReference: {fileID: 0}
-    - target: {fileID: 4904982257206242, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 4.6841407
-      objectReference: {fileID: 0}
-    - target: {fileID: 4904982257206242, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -71.13759
-      objectReference: {fileID: 0}
-    - target: {fileID: 4250109274614976, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 1.2915467
-      objectReference: {fileID: 0}
-    - target: {fileID: 4250109274614976, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -41.721313
-      objectReference: {fileID: 0}
-    - target: {fileID: 4250109274614976, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -78.73494
-      objectReference: {fileID: 0}
-    - target: {fileID: 4094698747882278, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 13.648624
-      objectReference: {fileID: 0}
-    - target: {fileID: 4094698747882278, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -29.565504
-      objectReference: {fileID: 0}
-    - target: {fileID: 4094698747882278, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -82.38055
-      objectReference: {fileID: 0}
-    - target: {fileID: 4502530491944394, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 1.2915467
-      objectReference: {fileID: 0}
-    - target: {fileID: 4502530491944394, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -41.721313
-      objectReference: {fileID: 0}
-    - target: {fileID: 4502530491944394, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -78.73494
-      objectReference: {fileID: 0}
-    - target: {fileID: 4897374354053644, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -3.0071566
-      objectReference: {fileID: 0}
-    - target: {fileID: 4897374354053644, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 4.6841407
-      objectReference: {fileID: 0}
-    - target: {fileID: 4897374354053644, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -71.13759
-      objectReference: {fileID: 0}
-    - target: {fileID: 4362653720202534, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 8.4048576e-30
-      objectReference: {fileID: 0}
-    - target: {fileID: 4362653720202534, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 1.0506072e-30
-      objectReference: {fileID: 0}
-    - target: {fileID: 4362653720202534, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4447759421104326, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 2.0401811e-15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4447759421104326, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 1.964382e-14
-      objectReference: {fileID: 0}
-    - target: {fileID: 4447759421104326, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 2.0402243e-15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4622156675914972, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 5.516867
-      objectReference: {fileID: 0}
-    - target: {fileID: 4622156675914972, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 73.64412
-      objectReference: {fileID: 0}
-    - target: {fileID: 4622156675914972, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 69.25784
-      objectReference: {fileID: 0}
-    - target: {fileID: 4159033694612762, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -7.998494e-15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4159033694612762, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -1.7160281e-15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4159033694612762, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 66.011826
-      objectReference: {fileID: 0}
-    - target: {fileID: 4909643457552354, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 7.80876
-      objectReference: {fileID: 0}
-    - target: {fileID: 4909643457552354, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -6.382661
-      objectReference: {fileID: 0}
-    - target: {fileID: 4909643457552354, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -39.514168
-      objectReference: {fileID: 0}
-    - target: {fileID: 4173495714638834, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -1.2077322
-      objectReference: {fileID: 0}
-    - target: {fileID: 4173495714638834, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -16.162489
-      objectReference: {fileID: 0}
-    - target: {fileID: 4173495714638834, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -38.23561
-      objectReference: {fileID: 0}
-    - target: {fileID: 4746254766196414, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 6.363365e-10
-      objectReference: {fileID: 0}
-    - target: {fileID: 4746254766196414, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -2.1005284e-10
-      objectReference: {fileID: 0}
-    - target: {fileID: 4746254766196414, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -18.267902
-      objectReference: {fileID: 0}
-    - target: {fileID: 4922689855533082, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -41.98722
-      objectReference: {fileID: 0}
-    - target: {fileID: 4922689855533082, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: 4008675252709476, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -5.639868
-      objectReference: {fileID: 0}
-    - target: {fileID: 4414545548949722, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -5.9248695
-      objectReference: {fileID: 0}
-    - target: {fileID: 4167584627008366, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4167584627008366, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4167584627008366, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4177841052307896, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 8.534816e-15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4177841052307896, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 6.8278526e-14
-      objectReference: {fileID: 0}
-    - target: {fileID: 4177841052307896, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 5.0072535e-29
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111021303809080, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 17.47029
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111021303809080, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 75.25312
-      objectReference: {fileID: 0}
-    - target: {fileID: 4111021303809080, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -157.26779
-      objectReference: {fileID: 0}
-    - target: {fileID: 4199496429364854, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -5.0752287e-15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4199496429364854, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 9.007727e-16
-      objectReference: {fileID: 0}
-    - target: {fileID: 4199496429364854, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 99.02979
-      objectReference: {fileID: 0}
-    - target: {fileID: 4849069599269942, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 3.5831983
-      objectReference: {fileID: 0}
-    - target: {fileID: 4849069599269942, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -6.7959213
-      objectReference: {fileID: 0}
-    - target: {fileID: 4849069599269942, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -62.31305
-      objectReference: {fileID: 0}
-    - target: {fileID: 4299631674963796, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 16.942995
-      objectReference: {fileID: 0}
-    - target: {fileID: 4299631674963796, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -38.969845
-      objectReference: {fileID: 0}
-    - target: {fileID: 4299631674963796, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 15.913116
-      objectReference: {fileID: 0}
-    - target: {fileID: 4553327210959372, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.0000000013759992
-      objectReference: {fileID: 0}
-    - target: {fileID: 4553327210959372, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 4.542161e-10
-      objectReference: {fileID: 0}
-    - target: {fileID: 4553327210959372, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -18.267902
-      objectReference: {fileID: 0}
-    - target: {fileID: 4129524386422316, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -41.98722
-      objectReference: {fileID: 0}
-    - target: {fileID: 4129524386422316, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: 4757630601066144, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 2.4070978
-      objectReference: {fileID: 0}
-    - target: {fileID: 4386535265974256, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 2.0266948
-      objectReference: {fileID: 0}
-    - target: {fileID: 4664653208066690, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 54.21014
-      objectReference: {fileID: 0}
-    - target: {fileID: 4664653208066690, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -62.04346
-      objectReference: {fileID: 0}
-    - target: {fileID: 4076254722564492, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -11.679604
-      objectReference: {fileID: 0}
-    - target: {fileID: 4076254722564492, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -5.4129043
-      objectReference: {fileID: 0}
-    - target: {fileID: 4076254722564492, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -19.487553
-      objectReference: {fileID: 0}
-    - target: {fileID: 4394916291248014, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -11.679604
-      objectReference: {fileID: 0}
-    - target: {fileID: 4394916291248014, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -5.4129043
-      objectReference: {fileID: 0}
-    - target: {fileID: 4394916291248014, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -19.487553
-      objectReference: {fileID: 0}
-    - target: {fileID: 4734965213256608, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -11.679604
-      objectReference: {fileID: 0}
-    - target: {fileID: 4734965213256608, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -5.4129043
-      objectReference: {fileID: 0}
-    - target: {fileID: 4734965213256608, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -19.487553
-      objectReference: {fileID: 0}
-    - target: {fileID: 4436452467632648, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 60.688877
-      objectReference: {fileID: 0}
-    - target: {fileID: 4436452467632648, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -24.421892
-      objectReference: {fileID: 0}
-    - target: {fileID: 4436452467632648, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 48.91315
-      objectReference: {fileID: 0}
-    - target: {fileID: 4428087995187844, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.0000024408448
-      objectReference: {fileID: 0}
-    - target: {fileID: 4428087995187844, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 125.789856
-      objectReference: {fileID: 0}
-    - target: {fileID: 4428087995187844, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 117.95654
-      objectReference: {fileID: 0}
-    - target: {fileID: 4971443297630912, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -1.5577136
-      objectReference: {fileID: 0}
-    - target: {fileID: 4971443297630912, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -11.853601
-      objectReference: {fileID: 0}
-    - target: {fileID: 4971443297630912, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -7.3710847
-      objectReference: {fileID: 0}
-    - target: {fileID: 4442972415832932, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -1.5577136
-      objectReference: {fileID: 0}
-    - target: {fileID: 4442972415832932, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -11.853601
-      objectReference: {fileID: 0}
-    - target: {fileID: 4442972415832932, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -7.3710847
-      objectReference: {fileID: 0}
-    - target: {fileID: 4165370982191942, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -1.5577136
-      objectReference: {fileID: 0}
-    - target: {fileID: 4165370982191942, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -11.853601
-      objectReference: {fileID: 0}
-    - target: {fileID: 4165370982191942, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -7.3710847
-      objectReference: {fileID: 0}
-    - target: {fileID: 4855584126136522, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 69.30485
-      objectReference: {fileID: 0}
-    - target: {fileID: 4855584126136522, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -4.4500914
-      objectReference: {fileID: 0}
-    - target: {fileID: 4855584126136522, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 78.45893
-      objectReference: {fileID: 0}
-    - target: {fileID: 4797408989271288, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 34.9975
-      objectReference: {fileID: 0}
-    - target: {fileID: 4797408989271288, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 139.007
-      objectReference: {fileID: 0}
-    - target: {fileID: 4797408989271288, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -94.657196
-      objectReference: {fileID: 0}
-    - target: {fileID: 4857693815710428, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 11.979832
-      objectReference: {fileID: 0}
-    - target: {fileID: 4857693815710428, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0.0003926778
-      objectReference: {fileID: 0}
-    - target: {fileID: 4857693815710428, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.00033619822
-      objectReference: {fileID: 0}
-    - target: {fileID: 4155232288320326, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -74.004845
-      objectReference: {fileID: 0}
-    - target: {fileID: 4155232288320326, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 34.49342
-      objectReference: {fileID: 0}
-    - target: {fileID: 4155232288320326, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -3.306514
-      objectReference: {fileID: 0}
-    - target: {fileID: 4804812091140662, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 32.61956
-      objectReference: {fileID: 0}
-    - target: {fileID: 4804812091140662, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 15.758222
-      objectReference: {fileID: 0}
-    - target: {fileID: 4804812091140662, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -62.432766
-      objectReference: {fileID: 0}
-    - target: {fileID: 4299115716299244, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 57.960842
-      objectReference: {fileID: 0}
-    - target: {fileID: 4299115716299244, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 80.94232
-      objectReference: {fileID: 0}
-    - target: {fileID: 4299115716299244, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 115.28179
-      objectReference: {fileID: 0}
-    - target: {fileID: 4310400518740042, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 7.6647663
-      objectReference: {fileID: 0}
-    - target: {fileID: 4310400518740042, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 19.937689
-      objectReference: {fileID: 0}
-    - target: {fileID: 4310400518740042, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -44.639202
-      objectReference: {fileID: 0}
-    - target: {fileID: 4115701267117082, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -3.2494383
-      objectReference: {fileID: 0}
-    - target: {fileID: 4115701267117082, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 8.25275
-      objectReference: {fileID: 0}
-    - target: {fileID: 4115701267117082, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -14.805813
-      objectReference: {fileID: 0}
-    - target: {fileID: 4659530230324112, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -13.720256
-      objectReference: {fileID: 0}
-    - target: {fileID: 4659530230324112, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -81.790504
-      objectReference: {fileID: 0}
-    - target: {fileID: 4659530230324112, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -31.311037
-      objectReference: {fileID: 0}
-    - target: {fileID: 4442951983710732, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 46.659485
-      objectReference: {fileID: 0}
-    - target: {fileID: 4973359118205660, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 46.276794
-      objectReference: {fileID: 0}
-    - target: {fileID: 4556108289399672, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -1.8060422
-      objectReference: {fileID: 0}
-    - target: {fileID: 4556108289399672, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 58.254467
-      objectReference: {fileID: 0}
-    - target: {fileID: 4556108289399672, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 60.028637
-      objectReference: {fileID: 0}
-    - target: {fileID: 4027338641033514, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 10.881778
-      objectReference: {fileID: 0}
-    - target: {fileID: 4027338641033514, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -13.640573
-      objectReference: {fileID: 0}
-    - target: {fileID: 4027338641033514, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 52.904716
-      objectReference: {fileID: 0}
-    - target: {fileID: 4249137482126668, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -18.556631
-      objectReference: {fileID: 0}
-    - target: {fileID: 4249137482126668, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -153.95082
-      objectReference: {fileID: 0}
-    - target: {fileID: 4249137482126668, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -134.88116
-      objectReference: {fileID: 0}
-    - target: {fileID: 4884517018927474, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.019168573
-      objectReference: {fileID: 0}
-    - target: {fileID: 4884517018927474, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0.046470433
-      objectReference: {fileID: 0}
-    - target: {fileID: 4884517018927474, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -0.08688258
-      objectReference: {fileID: 0}
-    - target: {fileID: 4605001771502036, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 10.156367
-      objectReference: {fileID: 0}
-    - target: {fileID: 4605001771502036, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -153.61372
-      objectReference: {fileID: 0}
-    - target: {fileID: 4605001771502036, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 160.11818
-      objectReference: {fileID: 0}
-    - target: {fileID: 4763339926373230, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 7.664767
-      objectReference: {fileID: 0}
-    - target: {fileID: 4763339926373230, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 19.93769
-      objectReference: {fileID: 0}
-    - target: {fileID: 4763339926373230, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -44.639202
-      objectReference: {fileID: 0}
-    - target: {fileID: 4476634994847308, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -3.278963
-      objectReference: {fileID: 0}
-    - target: {fileID: 4476634994847308, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 8.149159
-      objectReference: {fileID: 0}
-    - target: {fileID: 4476634994847308, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -14.596082
-      objectReference: {fileID: 0}
-    - target: {fileID: 4871081940850434, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -13.720256
-      objectReference: {fileID: 0}
-    - target: {fileID: 4871081940850434, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -81.790504
-      objectReference: {fileID: 0}
-    - target: {fileID: 4871081940850434, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -31.311037
-      objectReference: {fileID: 0}
-    - target: {fileID: 4195072140609048, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 3.539133
-      objectReference: {fileID: 0}
-    - target: {fileID: 4119176931533884, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 3.350729
-      objectReference: {fileID: 0}
-    - target: {fileID: 4793067716399302, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 2.0313993
-      objectReference: {fileID: 0}
-    - target: {fileID: 4793067716399302, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 5.9797716
-      objectReference: {fileID: 0}
-    - target: {fileID: 4793067716399302, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.25251803
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794622060116742, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -2.1401785e-15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794622060116742, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -4.280357e-15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4794622060116742, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 2.0474513e-13
-      objectReference: {fileID: 0}
-    - target: {fileID: 4497940890583644, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -9.622858
-      objectReference: {fileID: 0}
-    - target: {fileID: 4497940890583644, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 29.068861
-      objectReference: {fileID: 0}
-    - target: {fileID: 4497940890583644, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -1.7768664
-      objectReference: {fileID: 0}
-    - target: {fileID: 4270431302694314, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -4.1000948e-23
-      objectReference: {fileID: 0}
-    - target: {fileID: 4270431302694314, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -1.0470618e-22
-      objectReference: {fileID: 0}
-    - target: {fileID: 4270431302694314, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 4.7509894e-21
-      objectReference: {fileID: 0}
-    - target: {fileID: 4981504934901166, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 74.40391
-      objectReference: {fileID: 0}
-    - target: {fileID: 4981504934901166, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 120.88476
-      objectReference: {fileID: 0}
-    - target: {fileID: 4981504934901166, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 19.254705
-      objectReference: {fileID: 0}
-    - target: {fileID: 4732661282428884, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 4.584708
-      objectReference: {fileID: 0}
-    - target: {fileID: 4732661282428884, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -9.104256
-      objectReference: {fileID: 0}
-    - target: {fileID: 4732661282428884, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 26.510046
-      objectReference: {fileID: 0}
-    - target: {fileID: 4598360249674770, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4598360249674770, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 6.7344823
-      objectReference: {fileID: 0}
-    - target: {fileID: 4598360249674770, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4188727087985320, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4188727087985320, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -11.540324
-      objectReference: {fileID: 0}
-    - target: {fileID: 4188727087985320, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -16.922228
-      objectReference: {fileID: 0}
-    - target: {fileID: 4571530493803198, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -5.169114
-      objectReference: {fileID: 0}
-    - target: {fileID: 4571530493803198, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 2.1432414
-      objectReference: {fileID: 0}
-    - target: {fileID: 4571530493803198, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 53.723343
-      objectReference: {fileID: 0}
-    - target: {fileID: 4525627253653174, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -37.099506
-      objectReference: {fileID: 0}
-    - target: {fileID: 4525627253653174, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: 4938269475689786, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 67.95134
-      objectReference: {fileID: 0}
-    - target: {fileID: 4938269475689786, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 128.10733
-      objectReference: {fileID: 0}
-    - target: {fileID: 4938269475689786, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 41.270485
-      objectReference: {fileID: 0}
-    - target: {fileID: 4593902651856712, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.12206752
-      objectReference: {fileID: 0}
-    - target: {fileID: 4593902651856712, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -3.0699966
-      objectReference: {fileID: 0}
-    - target: {fileID: 4593902651856712, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -0.49565056
-      objectReference: {fileID: 0}
-    - target: {fileID: 4362526145503588, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.58023965
-      objectReference: {fileID: 0}
-    - target: {fileID: 4362526145503588, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -3.197428
-      objectReference: {fileID: 0}
-    - target: {fileID: 4362526145503588, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.86643267
-      objectReference: {fileID: 0}
-    - target: {fileID: 4378656680143560, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 1.213407
-      objectReference: {fileID: 0}
-    - target: {fileID: 4378656680143560, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -3.0268807
-      objectReference: {fileID: 0}
-    - target: {fileID: 4378656680143560, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 2.7475133
-      objectReference: {fileID: 0}
-    - target: {fileID: 4777922903619328, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 1.6004636
-      objectReference: {fileID: 0}
-    - target: {fileID: 4777922903619328, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -2.2168233
-      objectReference: {fileID: 0}
-    - target: {fileID: 4777922903619328, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 5.0165553
-      objectReference: {fileID: 0}
-    - target: {fileID: 4768832312599610, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 1.7027535
-      objectReference: {fileID: 0}
-    - target: {fileID: 4768832312599610, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -1.2237439
-      objectReference: {fileID: 0}
-    - target: {fileID: 4768832312599610, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 7.155542
-      objectReference: {fileID: 0}
-    - target: {fileID: 4595774504974656, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 1.5796978
-      objectReference: {fileID: 0}
-    - target: {fileID: 4595774504974656, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0.053741693
-      objectReference: {fileID: 0}
-    - target: {fileID: 4595774504974656, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 8.494317
-      objectReference: {fileID: 0}
-    - target: {fileID: 4206595825890400, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -2.4110298
-      objectReference: {fileID: 0}
-    - target: {fileID: 4832979152384150, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.5525359
-      objectReference: {fileID: 0}
-    - target: {fileID: 4832979152384150, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -91.43308
-      objectReference: {fileID: 0}
-    - target: {fileID: 4832979152384150, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 21.102081
-      objectReference: {fileID: 0}
-    - target: {fileID: 4832229852634924, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.48532352
-      objectReference: {fileID: 0}
-    - target: {fileID: 4832229852634924, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -1.4572192
-      objectReference: {fileID: 0}
-    - target: {fileID: 4832229852634924, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 18.438381
-      objectReference: {fileID: 0}
-    - target: {fileID: 4967351914957016, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.5190689
-      objectReference: {fileID: 0}
-    - target: {fileID: 4967351914957016, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -1.4455415
-      objectReference: {fileID: 0}
-    - target: {fileID: 4967351914957016, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 19.77022
-      objectReference: {fileID: 0}
-    - target: {fileID: 4705949342201916, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.5190689
-      objectReference: {fileID: 0}
-    - target: {fileID: 4705949342201916, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -1.4455415
-      objectReference: {fileID: 0}
-    - target: {fileID: 4705949342201916, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 19.77022
-      objectReference: {fileID: 0}
-    - target: {fileID: 4915656746316620, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.4413563
-      objectReference: {fileID: 0}
-    - target: {fileID: 4915656746316620, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -1.4711263
-      objectReference: {fileID: 0}
-    - target: {fileID: 4915656746316620, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 16.718227
-      objectReference: {fileID: 0}
-    - target: {fileID: 4603927007315420, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -2.5328355
-      objectReference: {fileID: 0}
-    - target: {fileID: 4603927007315420, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 88.55309
-      objectReference: {fileID: 0}
-    - target: {fileID: 4603927007315420, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 19.847277
-      objectReference: {fileID: 0}
-    - target: {fileID: 4965624308830098, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 65.22241
-      objectReference: {fileID: 0}
-    - target: {fileID: 4739165599846544, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -39.45027
-      objectReference: {fileID: 0}
-    - target: {fileID: 4948575957413208, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -27.137173
-      objectReference: {fileID: 0}
-    - target: {fileID: 4948575957413208, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: 4025031929011344, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -4.50229
-      objectReference: {fileID: 0}
-    - target: {fileID: 4025031929011344, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -13.693283
-      objectReference: {fileID: 0}
-    - target: {fileID: 4025031929011344, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -39.277565
-      objectReference: {fileID: 0}
-    - target: {fileID: 4214611251409320, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -15.778654
-      objectReference: {fileID: 0}
-    - target: {fileID: 4214611251409320, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 30.977037
-      objectReference: {fileID: 0}
-    - target: {fileID: 4214611251409320, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -96.78803
-      objectReference: {fileID: 0}
-    - target: {fileID: 4172782621879176, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -3.0071566
-      objectReference: {fileID: 0}
-    - target: {fileID: 4172782621879176, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 4.6841407
-      objectReference: {fileID: 0}
-    - target: {fileID: 4172782621879176, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -71.13759
-      objectReference: {fileID: 0}
-    - target: {fileID: 4148736256790394, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -4.582641
-      objectReference: {fileID: 0}
-    - target: {fileID: 4148736256790394, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -13.704151
-      objectReference: {fileID: 0}
-    - target: {fileID: 4148736256790394, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -0.07670338
-      objectReference: {fileID: 0}
-    - target: {fileID: 4599356386723012, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 13.648624
-      objectReference: {fileID: 0}
-    - target: {fileID: 4599356386723012, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -29.565504
-      objectReference: {fileID: 0}
-    - target: {fileID: 4599356386723012, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -82.38055
-      objectReference: {fileID: 0}
-    - target: {fileID: 4236363320248838, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -8.38944
-      objectReference: {fileID: 0}
-    - target: {fileID: 4236363320248838, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 3.611723
-      objectReference: {fileID: 0}
-    - target: {fileID: 4236363320248838, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -91.522675
-      objectReference: {fileID: 0}
-    - target: {fileID: 4779002211358998, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -16.703228
-      objectReference: {fileID: 0}
-    - target: {fileID: 4779002211358998, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -7.892706
-      objectReference: {fileID: 0}
-    - target: {fileID: 4779002211358998, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -73.44088
-      objectReference: {fileID: 0}
-    - target: {fileID: 4839108174941214, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -3.0071566
-      objectReference: {fileID: 0}
-    - target: {fileID: 4839108174941214, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 4.6841407
-      objectReference: {fileID: 0}
-    - target: {fileID: 4839108174941214, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -71.13759
-      objectReference: {fileID: 0}
-    - target: {fileID: 4812157219808860, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -8.38949
-      objectReference: {fileID: 0}
-    - target: {fileID: 4812157219808860, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 3.6117353
-      objectReference: {fileID: 0}
-    - target: {fileID: 4812157219808860, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.00008326047
-      objectReference: {fileID: 0}
-    - target: {fileID: 4528084358880370, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 73.16732
-      objectReference: {fileID: 0}
-    - target: {fileID: 4528084358880370, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -5.9396186
-      objectReference: {fileID: 0}
-    - target: {fileID: 4528084358880370, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -102.952156
-      objectReference: {fileID: 0}
-    - target: {fileID: 4474332651199030, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.4885857
-      objectReference: {fileID: 0}
-    - target: {fileID: 4474332651199030, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -84.09855
-      objectReference: {fileID: 0}
-    - target: {fileID: 4474332651199030, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -4.714857
-      objectReference: {fileID: 0}
-    - target: {fileID: 4314471303313392, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.48661426
-      objectReference: {fileID: 0}
-    - target: {fileID: 4314471303313392, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -4.693579
-      objectReference: {fileID: 0}
-    - target: {fileID: 4314471303313392, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.0013355991
-      objectReference: {fileID: 0}
-    - target: {fileID: 4240694396383352, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 13.648624
-      objectReference: {fileID: 0}
-    - target: {fileID: 4240694396383352, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -29.565504
-      objectReference: {fileID: 0}
-    - target: {fileID: 4240694396383352, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -82.38055
-      objectReference: {fileID: 0}
-    - target: {fileID: 4214997183193392, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -3.007156
-      objectReference: {fileID: 0}
-    - target: {fileID: 4214997183193392, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 4.6841416
-      objectReference: {fileID: 0}
-    - target: {fileID: 4214997183193392, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -74.88551
-      objectReference: {fileID: 0}
-    - target: {fileID: 4741048627962178, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.035895824
-      objectReference: {fileID: 0}
-    - target: {fileID: 4741048627962178, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.24275017
-      objectReference: {fileID: 0}
-    - target: {fileID: 4741048627962178, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -106.88214
-      objectReference: {fileID: 0}
-    - target: {fileID: 4871991885641684, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.10219312
-      objectReference: {fileID: 0}
-    - target: {fileID: 4871991885641684, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.474926
-      objectReference: {fileID: 0}
-    - target: {fileID: 4871991885641684, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.004122493
-      objectReference: {fileID: 0}
-    - target: {fileID: 4590758920472194, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 13.648624
-      objectReference: {fileID: 0}
-    - target: {fileID: 4590758920472194, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -29.565504
-      objectReference: {fileID: 0}
-    - target: {fileID: 4590758920472194, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -82.38055
-      objectReference: {fileID: 0}
-    - target: {fileID: 4957921896982732, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -3.007156
-      objectReference: {fileID: 0}
-    - target: {fileID: 4957921896982732, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 4.6841416
-      objectReference: {fileID: 0}
-    - target: {fileID: 4957921896982732, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -74.88551
-      objectReference: {fileID: 0}
-    - target: {fileID: 4588120079761296, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: 4152990401915204, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -5.547744
-      objectReference: {fileID: 0}
-    - target: {fileID: 4152990401915204, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -106.541145
-      objectReference: {fileID: 0}
-    - target: {fileID: 4152990401915204, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 151.9055
-      objectReference: {fileID: 0}
-    - target: {fileID: 4448373506279882, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -17.470297
-      objectReference: {fileID: 0}
-    - target: {fileID: 4448373506279882, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -104.74686
-      objectReference: {fileID: 0}
-    - target: {fileID: 4448373506279882, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -165.46916
-      objectReference: {fileID: 0}
-    - target: {fileID: 4897755059109612, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.000000682946
-      objectReference: {fileID: 0}
-    - target: {fileID: 4897755059109612, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0.0000004240744
-      objectReference: {fileID: 0}
-    - target: {fileID: 4897755059109612, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -121.69485
-      objectReference: {fileID: 0}
-    - target: {fileID: 4597981811371936, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4228230008819186, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -7.239843e-15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4228230008819186, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 1.3529716e-14
-      objectReference: {fileID: 0}
-    - target: {fileID: 4228230008819186, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -140.60904
-      objectReference: {fileID: 0}
-    - target: {fileID: 4505551458892700, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -11.381919
-      objectReference: {fileID: 0}
-    - target: {fileID: 4505551458892700, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -16.873306
-      objectReference: {fileID: 0}
-    - target: {fileID: 4505551458892700, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 4.648395
-      objectReference: {fileID: 0}
-    - target: {fileID: 4548003439681464, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 4548003439681464, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -42.10873
-      objectReference: {fileID: 0}
-    - target: {fileID: 4242726297461484, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4352037176262768, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 4.2042946e-15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4352037176262768, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 7.843259e-15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4352037176262768, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 86.93508
-      objectReference: {fileID: 0}
-    - target: {fileID: 4024356273036104, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4024356273036104, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4024356273036104, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 3.747913
-      objectReference: {fileID: 0}
-    - target: {fileID: 4975463029387872, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 36.91184
-      objectReference: {fileID: 0}
-    - target: {fileID: 4975463029387872, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 9.08205
-      objectReference: {fileID: 0}
-    - target: {fileID: 4975463029387872, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -1.2250776
-      objectReference: {fileID: 0}
-    - target: {fileID: 4129546071800724, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -13.756255
-      objectReference: {fileID: 0}
-    - target: {fileID: 4129546071800724, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -14.023803
-      objectReference: {fileID: 0}
-    - target: {fileID: 4129546071800724, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.99952453
-      objectReference: {fileID: 0}
-    - target: {fileID: 4141025084213792, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.00000038723283
-      objectReference: {fileID: 0}
-    - target: {fileID: 4141025084213792, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.00000011187478
-      objectReference: {fileID: 0}
-    - target: {fileID: 4141025084213792, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 73.59047
-      objectReference: {fileID: 0}
-    - target: {fileID: 4290755385985536, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -4.2898073
-      objectReference: {fileID: 0}
-    - target: {fileID: 4290755385985536, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.000003901156
-      objectReference: {fileID: 0}
-    - target: {fileID: 4290755385985536, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.00000013194631
-      objectReference: {fileID: 0}
-    - target: {fileID: 4294881462641002, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -21.687075
-      objectReference: {fileID: 0}
-    - target: {fileID: 4294881462641002, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -9.132456
-      objectReference: {fileID: 0}
-    - target: {fileID: 4294881462641002, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -1.8568034
-      objectReference: {fileID: 0}
-    - target: {fileID: 4141558994540542, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 69.26742
-      objectReference: {fileID: 0}
-    - target: {fileID: 4141558994540542, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: 4141558994540542, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 4495968998489408, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 4.584708
-      objectReference: {fileID: 0}
-    - target: {fileID: 4495968998489408, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -9.104256
-      objectReference: {fileID: 0}
-    - target: {fileID: 4495968998489408, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 26.510046
-      objectReference: {fileID: 0}
-    - target: {fileID: 4954294968998498, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -87.47684
-      objectReference: {fileID: 0}
-    - target: {fileID: 4954294968998498, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 179.99962
-      objectReference: {fileID: 0}
-    - target: {fileID: 4954294968998498, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -179.99954
-      objectReference: {fileID: 0}
-    - target: {fileID: 4993280429354318, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -6.8131933
-      objectReference: {fileID: 0}
-    - target: {fileID: 4993280429354318, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 5.4797848e-15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4993280429354318, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -3.1524864e-16
-      objectReference: {fileID: 0}
-    - target: {fileID: 4096996112407030, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 69.26743
-      objectReference: {fileID: 0}
-    - target: {fileID: 4096996112407030, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -90
-      objectReference: {fileID: 0}
-    - target: {fileID: 4096996112407030, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 180
-      objectReference: {fileID: 0}
-    - target: {fileID: 4737165453179956, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 11.386864
-      objectReference: {fileID: 0}
-    - target: {fileID: 4737165453179956, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -5.7003958e-15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4737165453179956, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 4.2979943e-15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4166113169488546, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -32.772305
-      objectReference: {fileID: 0}
-    - target: {fileID: 4166113169488546, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -3.693097
-      objectReference: {fileID: 0}
-    - target: {fileID: 4166113169488546, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -4.446201
-      objectReference: {fileID: 0}
-    - target: {fileID: 4978770569315924, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4978770569315924, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 6.6566133
-      objectReference: {fileID: 0}
-    - target: {fileID: 4978770569315924, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4217479396287186, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4217479396287186, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -11.540324
-      objectReference: {fileID: 0}
-    - target: {fileID: 4217479396287186, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -16.922228
-      objectReference: {fileID: 0}
-    - target: {fileID: 4351919925230094, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -5.169114
-      objectReference: {fileID: 0}
-    - target: {fileID: 4351919925230094, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 2.1432438
-      objectReference: {fileID: 0}
-    - target: {fileID: 4351919925230094, guid: 54f08473df2a94348a95272458da3885, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 53.723343
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 54f08473df2a94348a95272458da3885, type: 3}
 --- !u!1 &550007146
 GameObject:
   m_ObjectHideFlags: 0
@@ -1680,6 +211,97 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!95 &649128391 stripped
+Animator:
+  m_CorrespondingSourceObject: {fileID: 9500000, guid: ae495434e84223e4986a98db34c5941a,
+    type: 3}
+  m_PrefabInstance: {fileID: 1034513314}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &886668385 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+    type: 3}
+  m_PrefabInstance: {fileID: 1282747182}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1034513314
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 100062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_Name
+      value: Low_Wolf_v01
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -19.346
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.8821
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.8821
+      objectReference: {fileID: 0}
+    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.8821
+      objectReference: {fileID: 0}
+    - target: {fileID: 9500000, guid: ae495434e84223e4986a98db34c5941a, type: 3}
+      propertyPath: m_Controller
+      value: 
+      objectReference: {fileID: 9100000, guid: aa92fea03dfbd4862bdc076cb9438978, type: 2}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ae495434e84223e4986a98db34c5941a, type: 3}
 --- !u!1 &1229721269
 GameObject:
   m_ObjectHideFlags: 0
@@ -1772,7 +394,7 @@ Transform:
   m_LocalScale: {x: 5, y: 1, z: 5}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!95 &1229721274
 Animator:
@@ -1784,7 +406,7 @@ Animator:
   m_GameObject: {fileID: 1229721269}
   m_Enabled: 1
   m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: f93dd60160f624d439977cde02d615a4, type: 2}
+  m_Controller: {fileID: 9100000, guid: aa92fea03dfbd4862bdc076cb9438978, type: 2}
   m_CullingMode: 0
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
@@ -1803,7 +425,7 @@ PrefabInstance:
     - target: {fileID: 0}
       propertyPath: playerCharacter
       value: 
-      objectReference: {fileID: 227121202}
+      objectReference: {fileID: 0}
     - target: {fileID: 2472492525004171323, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
       propertyPath: m_Name
@@ -1972,7 +594,7 @@ PrefabInstance:
     - target: {fileID: 5799114557473636308, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3600359970751833494, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
@@ -1982,27 +604,59 @@ PrefabInstance:
     - target: {fileID: 1667461370911226743, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
       propertyPath: m_textInfo.characterCount
-      value: 0
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 1667461370911226743, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
       propertyPath: m_textInfo.spaceCount
-      value: 0
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1667461370911226743, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
       propertyPath: m_textInfo.wordCount
-      value: 0
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1667461370911226743, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
       propertyPath: m_textInfo.lineCount
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1667461370911226743, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
       propertyPath: m_textInfo.pageCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1667461370911226743, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 13882ebfb9a95334296b00a5256ccbe7,
+        type: 2}
+    - target: {fileID: 1667461370911226743, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_sharedMaterial
+      value: 
+      objectReference: {fileID: -5732759394242628237, guid: 13882ebfb9a95334296b00a5256ccbe7,
+        type: 2}
+    - target: {fileID: 1667461370911226743, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontColor.r
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1667461370911226743, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontColor.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1667461370911226743, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontColor.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1667461370911226743, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4278190080
       objectReference: {fileID: 0}
     - target: {fileID: 6935892264420744417, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
@@ -2014,30 +668,97 @@ PrefabInstance:
       propertyPath: m_Enabled
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7307795879217515016, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_Color.a
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1864854612316470025, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
       propertyPath: m_Enabled
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1864854612316470025, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_TargetGraphic
+      value: 
+      objectReference: {fileID: 886668385}
+    - target: {fileID: 1864854612316470025, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_Colors.m_NormalColor.r
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1864854612316470025, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_Colors.m_NormalColor.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1864854612316470025, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_Colors.m_NormalColor.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1864854612316470025, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_Colors.m_NormalColor.a
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
       propertyPath: m_textInfo.characterCount
-      value: 0
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
       propertyPath: m_textInfo.wordCount
-      value: 0
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
       propertyPath: m_textInfo.lineCount
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
       propertyPath: m_textInfo.pageCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 13882ebfb9a95334296b00a5256ccbe7,
+        type: 2}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_sharedMaterial
+      value: 
+      objectReference: {fileID: -5732759394242628237, guid: 13882ebfb9a95334296b00a5256ccbe7,
+        type: 2}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontStyle
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontColor.r
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontColor.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontColor.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4278190080
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 30d40e39fc8e482418064821b11596d2, type: 3}
@@ -2152,7 +873,7 @@ RectTransform:
   m_Children:
   - {fileID: 1282747183}
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2172,7 +893,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   whitePanel: {fileID: 1484688122}
-  playerCharacterAnimator: {fileID: 227121208}
+  playerCharacterAnimator: {fileID: 649128391}
 --- !u!1 &2026808120
 GameObject:
   m_ObjectHideFlags: 0
@@ -2237,7 +958,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2092129940
 GameObject:

--- a/Assets/Scenes/DeathScene.unity
+++ b/Assets/Scenes/DeathScene.unity
@@ -211,12 +211,127 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!1 &550289234 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7058954467443417514, guid: b5564caf433bd44caa131a7593260484,
+    type: 3}
+  m_PrefabInstance: {fileID: 814915698}
+  m_PrefabAsset: {fileID: 0}
 --- !u!95 &649128391 stripped
 Animator:
-  m_CorrespondingSourceObject: {fileID: 9500000, guid: ae495434e84223e4986a98db34c5941a,
+  m_CorrespondingSourceObject: {fileID: 1087349226842852349, guid: decadfc27aec3c9478b0f0120832b406,
     type: 3}
-  m_PrefabInstance: {fileID: 1034513314}
+  m_PrefabInstance: {fileID: 1087349226930312511}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &814915698
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2415918641645154796, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: m_Name
+      value: AudioManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 40.940826
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -172.45729
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.45224
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719382801887882737, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[0].name
+      value: uiHover
+      objectReference: {fileID: 0}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[1].name
+      value: uiClick
+      objectReference: {fileID: 0}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[1].clip
+      value: 
+      objectReference: {fileID: 8300000, guid: a9407594401e72b45a847693d0d39351, type: 3}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[0].clip
+      value: 
+      objectReference: {fileID: 8300000, guid: 2ba5b4a3d479ec6468afd790ca50af81, type: 3}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[0].volume
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[1].volume
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: audioSources
+      value: 
+      objectReference: {fileID: 550289234}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b5564caf433bd44caa131a7593260484, type: 3}
 --- !u!114 &886668385 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
@@ -229,79 +344,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &1034513314
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 100062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
-      propertyPath: m_Name
-      value: Low_Wolf_v01
-      objectReference: {fileID: 0}
-    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -19.346
-      objectReference: {fileID: 0}
-    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
-      propertyPath: m_RootOrder
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 1.8821
-      objectReference: {fileID: 0}
-    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 1.8821
-      objectReference: {fileID: 0}
-    - target: {fileID: 400062, guid: ae495434e84223e4986a98db34c5941a, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 1.8821
-      objectReference: {fileID: 0}
-    - target: {fileID: 9500000, guid: ae495434e84223e4986a98db34c5941a, type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 9100000, guid: aa92fea03dfbd4862bdc076cb9438978, type: 2}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ae495434e84223e4986a98db34c5941a, type: 3}
 --- !u!1 &1229721269
 GameObject:
   m_ObjectHideFlags: 0
@@ -422,6 +464,16 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1946647073}
     m_Modifications:
+    - target: {fileID: 8211705799578569536, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: btnHoverSound
+      value: uiHover
+      objectReference: {fileID: 0}
+    - target: {fileID: 8211705799578569536, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: btnClickSound
+      value: uiClick
+      objectReference: {fileID: 0}
     - target: {fileID: 0}
       propertyPath: playerCharacter
       value: 
@@ -430,6 +482,83 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: DeathMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_textInfo.characterCount
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_textInfo.wordCount
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_textInfo.lineCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_textInfo.pageCount
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 13882ebfb9a95334296b00a5256ccbe7,
+        type: 2}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_sharedMaterial
+      value: 
+      objectReference: {fileID: -5732759394242628237, guid: 13882ebfb9a95334296b00a5256ccbe7,
+        type: 2}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontStyle
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontColor.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontColor.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontSizeBase
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_firstOverflowCharacterIndex
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_enableVertexGradient
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5591446699292486299, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
@@ -594,7 +723,7 @@ PrefabInstance:
     - target: {fileID: 5799114557473636308, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3600359970751833494, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
@@ -619,7 +748,7 @@ PrefabInstance:
     - target: {fileID: 1667461370911226743, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
       propertyPath: m_textInfo.lineCount
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1667461370911226743, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
@@ -657,6 +786,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_fontColor32.rgba
       value: 4278190080
+      objectReference: {fileID: 0}
+    - target: {fileID: 1667461370911226743, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontSize
+      value: 70
+      objectReference: {fileID: 0}
+    - target: {fileID: 1667461370911226743, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_fontSizeBase
+      value: 70
+      objectReference: {fileID: 0}
+    - target: {fileID: 1667461370911226743, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_firstOverflowCharacterIndex
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6935892264420744417, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
@@ -703,62 +847,90 @@ PrefabInstance:
       propertyPath: m_Colors.m_NormalColor.a
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+    - target: {fileID: 1864854612316470025, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
-      propertyPath: m_textInfo.characterCount
-      value: 9
+      propertyPath: m_Colors.m_HighlightedColor.r
+      value: 0.1882353
       objectReference: {fileID: 0}
-    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+    - target: {fileID: 1864854612316470025, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
-      propertyPath: m_textInfo.wordCount
-      value: 2
+      propertyPath: m_Colors.m_HighlightedColor.g
+      value: 0.9254902
       objectReference: {fileID: 0}
-    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+    - target: {fileID: 1864854612316470025, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
-      propertyPath: m_textInfo.lineCount
-      value: 1
+      propertyPath: m_Colors.m_HighlightedColor.b
+      value: 0.6156863
       objectReference: {fileID: 0}
-    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+    - target: {fileID: 1864854612316470025, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
-      propertyPath: m_textInfo.pageCount
-      value: 1
+      propertyPath: m_Colors.m_PressedColor.r
+      value: 0.1764706
       objectReference: {fileID: 0}
-    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+    - target: {fileID: 1864854612316470025, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
-      propertyPath: m_fontAsset
-      value: 
-      objectReference: {fileID: 11400000, guid: 13882ebfb9a95334296b00a5256ccbe7,
-        type: 2}
-    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
-        type: 3}
-      propertyPath: m_sharedMaterial
-      value: 
-      objectReference: {fileID: -5732759394242628237, guid: 13882ebfb9a95334296b00a5256ccbe7,
-        type: 2}
-    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
-        type: 3}
-      propertyPath: m_fontStyle
-      value: 16
+      propertyPath: m_Colors.m_PressedColor.g
+      value: 0.8
       objectReference: {fileID: 0}
-    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+    - target: {fileID: 1864854612316470025, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
-      propertyPath: m_fontColor.r
+      propertyPath: m_Colors.m_PressedColor.b
+      value: 0.5411765
+      objectReference: {fileID: 0}
+    - target: {fileID: 1864854612316470025, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_Colors.m_SelectedColor.r
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+    - target: {fileID: 1864854612316470025, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
-      propertyPath: m_fontColor.g
+      propertyPath: m_Colors.m_SelectedColor.g
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+    - target: {fileID: 1864854612316470025, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
-      propertyPath: m_fontColor.b
+      propertyPath: m_Colors.m_SelectedColor.b
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7336032013693115935, guid: 30d40e39fc8e482418064821b11596d2,
+    - target: {fileID: 7567846804340581682, guid: 30d40e39fc8e482418064821b11596d2,
         type: 3}
-      propertyPath: m_fontColor32.rgba
-      value: 4278190080
+      propertyPath: m_SizeDelta.x
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 7567846804340581682, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 7567846804340581682, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 119
+      objectReference: {fileID: 0}
+    - target: {fileID: 7567846804340581682, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7567846804340581682, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3990899980815794442, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -218
+      objectReference: {fileID: 0}
+    - target: {fileID: 3990899980815794442, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 500
+      objectReference: {fileID: 0}
+    - target: {fileID: 3990899980815794442, guid: 30d40e39fc8e482418064821b11596d2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 80
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 30d40e39fc8e482418064821b11596d2, type: 3}
@@ -873,7 +1045,7 @@ RectTransform:
   m_Children:
   - {fileID: 1282747183}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -958,7 +1130,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2092129940
 GameObject:
@@ -1037,9 +1209,78 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2092129940}
   m_LocalRotation: {x: 0.2041832, y: -0, z: -0, w: 0.97893274}
-  m_LocalPosition: {x: 0, y: 2.04, z: -22.4}
+  m_LocalPosition: {x: 0, y: 1.834, z: -22.4}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 23.563002, y: 0, z: 0}
+--- !u!1001 &1087349226930312511
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1424811160435630780, guid: decadfc27aec3c9478b0f0120832b406,
+        type: 3}
+      propertyPath: m_Name
+      value: PlayerDeathScene
+      objectReference: {fileID: 0}
+    - target: {fileID: 5904312009668761741, guid: decadfc27aec3c9478b0f0120832b406,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6.4575415
+      objectReference: {fileID: 0}
+    - target: {fileID: 5904312009668761741, guid: decadfc27aec3c9478b0f0120832b406,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 9.433847
+      objectReference: {fileID: 0}
+    - target: {fileID: 5904312009668761741, guid: decadfc27aec3c9478b0f0120832b406,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -18.595013
+      objectReference: {fileID: 0}
+    - target: {fileID: 5904312009668761741, guid: decadfc27aec3c9478b0f0120832b406,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5904312009668761741, guid: decadfc27aec3c9478b0f0120832b406,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5904312009668761741, guid: decadfc27aec3c9478b0f0120832b406,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5904312009668761741, guid: decadfc27aec3c9478b0f0120832b406,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5904312009668761741, guid: decadfc27aec3c9478b0f0120832b406,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5904312009668761741, guid: decadfc27aec3c9478b0f0120832b406,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5904312009668761741, guid: decadfc27aec3c9478b0f0120832b406,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5904312009668761741, guid: decadfc27aec3c9478b0f0120832b406,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: decadfc27aec3c9478b0f0120832b406, type: 3}

--- a/Assets/Scenes/MainMenuScene.unity
+++ b/Assets/Scenes/MainMenuScene.unity
@@ -553,7 +553,7 @@ PrefabInstance:
     - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
         type: 3}
       propertyPath: sounds.Array.size
-      value: 3
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
         type: 3}
@@ -610,9 +610,135 @@ PrefabInstance:
       propertyPath: sounds.Array.data[2].loop
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[3].name
+      value: ambBirds
+      objectReference: {fileID: 0}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[3].clip
+      value: 
+      objectReference: {fileID: 8300000, guid: 55b3948d57f934b41ba067f1b72b858f, type: 3}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[3].volume
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[3].loop
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[4].name
+      value: ambCrickets
+      objectReference: {fileID: 0}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[4].clip
+      value: 
+      objectReference: {fileID: 8300000, guid: 8d1fab9002809b24db2093808ec4382b, type: 3}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[4].volume
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[4].loop
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[5].name
+      value: ambOwl
+      objectReference: {fileID: 0}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[5].clip
+      value: 
+      objectReference: {fileID: 8300000, guid: 339091a2c7883a64ab8c5b59625522da, type: 3}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[5].volume
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3813881987453032669, guid: b5564caf433bd44caa131a7593260484,
+        type: 3}
+      propertyPath: sounds.Array.data[5].loop
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b5564caf433bd44caa131a7593260484, type: 3}
---- !u!43 &1093356047
+--- !u!1 &1868831178
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1868831181}
+  - component: {fileID: 1868831180}
+  - component: {fileID: 1868831179}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1868831179
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1868831178}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1868831180
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1868831178}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1868831181
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1868831178}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!43 &2069156673
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -775,72 +901,6 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1 &1868831178
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1868831181}
-  - component: {fileID: 1868831180}
-  - component: {fileID: 1868831179}
-  m_Layer: 0
-  m_Name: EventSystem
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1868831179
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1868831178}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
---- !u!114 &1868831180
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1868831178}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!4 &1868831181
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1868831178}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2086613280
 GameObject:
   m_ObjectHideFlags: 0
@@ -1003,7 +1063,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 1093356047}
+      objectReference: {fileID: 2069156673}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9190f0e1dc58f01468f7851127d6b1b0, type: 3}
 --- !u!1001 &7401620492174578649
@@ -1013,46 +1073,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 2356164278067699495, guid: 0e6a945b37454aa4c8963e471917a6a0,
-        type: 3}
-      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 901943343}
-    - target: {fileID: 2356164278067699495, guid: 0e6a945b37454aa4c8963e471917a6a0,
-        type: 3}
-      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 901943343}
-    - target: {fileID: 922839963764764720, guid: 0e6a945b37454aa4c8963e471917a6a0,
-        type: 3}
-      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 901943343}
-    - target: {fileID: 922839963764764720, guid: 0e6a945b37454aa4c8963e471917a6a0,
-        type: 3}
-      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 901943343}
-    - target: {fileID: 5507513998009535806, guid: 0e6a945b37454aa4c8963e471917a6a0,
-        type: 3}
-      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 901943343}
-    - target: {fileID: 5507513998009535806, guid: 0e6a945b37454aa4c8963e471917a6a0,
-        type: 3}
-      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 901943343}
-    - target: {fileID: 2842289204215641455, guid: 0e6a945b37454aa4c8963e471917a6a0,
-        type: 3}
-      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 901943343}
-    - target: {fileID: 2842289204215641455, guid: 0e6a945b37454aa4c8963e471917a6a0,
-        type: 3}
-      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 901943343}
     - target: {fileID: 0}
       propertyPath: m_Sprite
       value: 
@@ -1087,6 +1107,76 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2983065207450222849, guid: 0e6a945b37454aa4c8963e471917a6a0,
+        type: 3}
+      propertyPath: m_Colors.m_HighlightedColor.r
+      value: 0.1882353
+      objectReference: {fileID: 0}
+    - target: {fileID: 2983065207450222849, guid: 0e6a945b37454aa4c8963e471917a6a0,
+        type: 3}
+      propertyPath: m_Colors.m_HighlightedColor.g
+      value: 0.9254902
+      objectReference: {fileID: 0}
+    - target: {fileID: 2983065207450222849, guid: 0e6a945b37454aa4c8963e471917a6a0,
+        type: 3}
+      propertyPath: m_Colors.m_HighlightedColor.b
+      value: 0.6156863
+      objectReference: {fileID: 0}
+    - target: {fileID: 2983065207450222849, guid: 0e6a945b37454aa4c8963e471917a6a0,
+        type: 3}
+      propertyPath: m_Colors.m_PressedColor.r
+      value: 0.18039216
+      objectReference: {fileID: 0}
+    - target: {fileID: 2983065207450222849, guid: 0e6a945b37454aa4c8963e471917a6a0,
+        type: 3}
+      propertyPath: m_Colors.m_PressedColor.g
+      value: 0.8039216
+      objectReference: {fileID: 0}
+    - target: {fileID: 2983065207450222849, guid: 0e6a945b37454aa4c8963e471917a6a0,
+        type: 3}
+      propertyPath: m_Colors.m_PressedColor.b
+      value: 0.5411765
+      objectReference: {fileID: 0}
+    - target: {fileID: 2356164278067699495, guid: 0e6a945b37454aa4c8963e471917a6a0,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 901943343}
+    - target: {fileID: 2356164278067699495, guid: 0e6a945b37454aa4c8963e471917a6a0,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 901943343}
+    - target: {fileID: 922839963764764720, guid: 0e6a945b37454aa4c8963e471917a6a0,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 901943343}
+    - target: {fileID: 922839963764764720, guid: 0e6a945b37454aa4c8963e471917a6a0,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 901943343}
+    - target: {fileID: 5507513998009535806, guid: 0e6a945b37454aa4c8963e471917a6a0,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 901943343}
+    - target: {fileID: 5507513998009535806, guid: 0e6a945b37454aa4c8963e471917a6a0,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 901943343}
+    - target: {fileID: 2842289204215641455, guid: 0e6a945b37454aa4c8963e471917a6a0,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[0].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 901943343}
+    - target: {fileID: 2842289204215641455, guid: 0e6a945b37454aa4c8963e471917a6a0,
+        type: 3}
+      propertyPath: m_Delegates.Array.data[1].callback.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 901943343}
     - target: {fileID: 7401620491411800880, guid: 0e6a945b37454aa4c8963e471917a6a0,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -3462,36 +3552,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_textInfo.lineCount
       value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 2983065207450222849, guid: 0e6a945b37454aa4c8963e471917a6a0,
-        type: 3}
-      propertyPath: m_Colors.m_HighlightedColor.r
-      value: 0.1882353
-      objectReference: {fileID: 0}
-    - target: {fileID: 2983065207450222849, guid: 0e6a945b37454aa4c8963e471917a6a0,
-        type: 3}
-      propertyPath: m_Colors.m_HighlightedColor.g
-      value: 0.9254902
-      objectReference: {fileID: 0}
-    - target: {fileID: 2983065207450222849, guid: 0e6a945b37454aa4c8963e471917a6a0,
-        type: 3}
-      propertyPath: m_Colors.m_HighlightedColor.b
-      value: 0.6156863
-      objectReference: {fileID: 0}
-    - target: {fileID: 2983065207450222849, guid: 0e6a945b37454aa4c8963e471917a6a0,
-        type: 3}
-      propertyPath: m_Colors.m_PressedColor.r
-      value: 0.18039216
-      objectReference: {fileID: 0}
-    - target: {fileID: 2983065207450222849, guid: 0e6a945b37454aa4c8963e471917a6a0,
-        type: 3}
-      propertyPath: m_Colors.m_PressedColor.g
-      value: 0.8039216
-      objectReference: {fileID: 0}
-    - target: {fileID: 2983065207450222849, guid: 0e6a945b37454aa4c8963e471917a6a0,
-        type: 3}
-      propertyPath: m_Colors.m_PressedColor.b
-      value: 0.5411765
       objectReference: {fileID: 0}
     - target: {fileID: 6633902573294212378, guid: 0e6a945b37454aa4c8963e471917a6a0,
         type: 3}

--- a/Assets/Scripts/AbstractClasses/Damageable.cs
+++ b/Assets/Scripts/AbstractClasses/Damageable.cs
@@ -14,14 +14,22 @@ namespace AbstractClasses
         private static readonly int DieTrigger = Animator.StringToHash(Consts.Animation.DIE_TRIGGER);
 
         /// <summary>
-        /// Marks the player as hit after being hit.
+        /// Marks the entity as hit after being hit.
         /// </summary>
-        /// <param name="damage">The damage dealt to player</param>
+        /// <param name="damage">The damage dealt</param>
         /// <param name="attacker">The EnemyController of the attacker if it's an NPC.</param>
         public virtual void Hit(int damage, EnemyController attacker = null)
         {
             animator.SetTrigger(HitTrigger);
         }
+
+        /// <summary>
+        /// Does damage to the player. Implementation should call base.Hit(damage, attacker)
+        /// </summary>
+        /// <param name="damage">The damage dealth to the player</param>
+        /// <param name="health">The health of the entity after damage is dealt</param>
+        /// <param name="attacker">The EnemyController of the attacker if it's an NPC.</param>
+        public abstract void Hit(int damage, out int health, EnemyController attacker = null);
 
         public virtual void Die()
         {

--- a/Assets/Scripts/Entity/AttackLogic.cs
+++ b/Assets/Scripts/Entity/AttackLogic.cs
@@ -137,7 +137,9 @@ namespace Entity
                 // deal damage
                 // Add damage boost from weapon
                 int boostedDamage = damage + InventoryManager.Instance.DamageBoostFromEquipable;
-                Target.Hit(boostedDamage, _enemyController);
+                Target.Hit(boostedDamage, out int targetHealth, _enemyController);
+                if (targetHealth <= 0)
+                    StopAttack();
             }
 
             // end hit

--- a/Assets/Scripts/Entity/Enemy/EnemyState.cs
+++ b/Assets/Scripts/Entity/Enemy/EnemyState.cs
@@ -77,6 +77,18 @@ namespace Entity.Enemy {
                 base.Hit(damage);
         }
 
+        /// <summary>
+        /// Run away if NPC is not aggressive. Only do hit animation if not running away.
+        /// </summary>
+        /// <param name="damage">The damage dealt</param>
+        /// <param name="health">The health after damage was dealt.</param>
+        /// <param name="_">EnemyController is not used because this is an NPC.</param>
+        public override void Hit(int damage, out int health, EnemyController _)
+        {
+            Hit(damage, _);
+            health = this.health;
+        }
+
         private void ChangeHealth(int changeBy)
         {
             int updatedValue = health + changeBy;

--- a/Assets/Scripts/Entity/Player/PlayerState.cs
+++ b/Assets/Scripts/Entity/Player/PlayerState.cs
@@ -32,8 +32,6 @@ namespace Entity.Player
 
         public int Sanity => sanity;
 
-        private bool _playerIsDead;
-
         public static event PlayerStateChanged OnPlayerHealthUpdate;
         public static event PlayerStateChanged OnPlayerSaturationUpdate;
         public static event PlayerStateChanged OnPlayerHydrationUpdate;
@@ -88,12 +86,7 @@ namespace Entity.Player
             OnPlayerSanityUpdate?.Invoke(value);
         }
 
-        private void Awake()
-        {
-            _playerIsDead = false;
-        }
 
-        //Interface
         private void ChangePlayerHealth(int changeBy)
         {
             int updatedValue = health + changeBy;
@@ -191,14 +184,8 @@ namespace Entity.Player
 
         public override void Die()
         {
-            //This is a quick fix, to prevent invoking "OnPlayerDeath" an infinite amount of times
-            //TODO: rm condition, class variable and awake(), once a "disengage mechanic" has been added to "AttackLogic"
-            if (!_playerIsDead)
-            {
-                _playerIsDead = true;
-                OnPlayerDeath?.Invoke();
-            }
-            
+            base.Die();
+            OnPlayerDeath?.Invoke();
         }
     }
 }

--- a/Assets/Scripts/Entity/Player/PlayerState.cs
+++ b/Assets/Scripts/Entity/Player/PlayerState.cs
@@ -146,13 +146,25 @@ namespace Entity.Player
         /// <summary>
         /// Does damage to the player.
         /// </summary>
-        /// <param name="damage">The damage dealt to player</param>
+        /// <param name="damage">The damage dealt to the player</param>
         /// <param name="attacker">The EnemyController of the enemy</param>
         public override void Hit(int damage, EnemyController attacker = null)
         {
             base.Hit(damage);
             ChangePlayerHealth(-damage);
             OnPlayerHit?.Invoke(attacker);
+        }
+
+        /// <summary>
+        /// Does damage to the player.
+        /// </summary>
+        /// <param name="damage">The damage dealth to the player</param>
+        /// <param name="health">The health of the player after damage is dealt</param>
+        /// <param name="attacker">The EnemyController of the enemy</param>
+        public override void Hit(int damage, out int health, EnemyController attacker = null)
+        {
+            Hit(damage, attacker);
+            health = this.health;
         }
 
         /// <summary>

--- a/Assets/Scripts/Entity/Player/PlayerState.cs
+++ b/Assets/Scripts/Entity/Player/PlayerState.cs
@@ -1,4 +1,5 @@
-﻿using AbstractClasses;
+﻿using System;
+using AbstractClasses;
 using Entity.Enemy;
 using Inventory;
 using Remote;
@@ -30,6 +31,8 @@ namespace Entity.Player
         private int sanity;
 
         public int Sanity => sanity;
+
+        private bool _playerIsDead;
 
         public static event PlayerStateChanged OnPlayerHealthUpdate;
         public static event PlayerStateChanged OnPlayerSaturationUpdate;
@@ -83,6 +86,11 @@ namespace Entity.Player
         {
             sanity = value;
             OnPlayerSanityUpdate?.Invoke(value);
+        }
+
+        private void Awake()
+        {
+            _playerIsDead = false;
         }
 
         //Interface
@@ -171,7 +179,14 @@ namespace Entity.Player
 
         public override void Die()
         {
-            OnPlayerDeath?.Invoke();
+            //This is a quick fix, to prevent invoking "OnPlayerDeath" an infinite amount of times
+            //TODO: rm condition, class variable and awake(), once a "disengage mechanic" has been added to "AttackLogic"
+            if (!_playerIsDead)
+            {
+                _playerIsDead = true;
+                OnPlayerDeath?.Invoke();
+            }
+            
         }
     }
 }

--- a/Assets/Scripts/GameAudio/PlayTheme.cs
+++ b/Assets/Scripts/GameAudio/PlayTheme.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿using Constants;
 using Managers;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace GameAudio
 {
@@ -8,10 +9,22 @@ namespace GameAudio
     {
         [SerializeField][Tooltip("Name of the theme song audio")]
         private string themeSong;
-        
-        void Start()
+
+        private void Awake()
         {
-        AudioManager.Instance.FadeIn(themeSong,3);
+            SceneManager.sceneUnloaded += MenuSceneUnloaded;
+        }
+
+        private void Start()
+        {
+            AudioManager.Instance.FadeIn(themeSong,3);
+        }
+
+        private void MenuSceneUnloaded(Scene scene) 
+        {
+            if (scene.buildIndex != Consts.Scene.MAIN_MENU) return;
+            AudioManager.Instance.FadeOut(themeSong,10);   
+            SceneManager.sceneUnloaded -= MenuSceneUnloaded;
         }
     }
 }

--- a/Assets/Scripts/Managers/AudioManager.cs
+++ b/Assets/Scripts/Managers/AudioManager.cs
@@ -8,7 +8,7 @@ namespace Managers
     /**
      * Play sounds with 'AudioManager.Instance.Play("name");'
      */
-    public class AudioManager : Singleton<AudioManager>
+    public class AudioManager : SingletonImmortal<AudioManager>
     {
         [SerializeField][Tooltip("Container for all sounds")]
         private List<Sound> sounds;

--- a/Assets/Scripts/Managers/SingletonImmortal.cs
+++ b/Assets/Scripts/Managers/SingletonImmortal.cs
@@ -1,0 +1,27 @@
+﻿using UnityEngine;
+
+namespace Managers
+{
+    public class SingletonImmortal<T> : MonoBehaviour where T : class
+    {
+        /// <summary>
+        /// Globally accessible Instance, which doesn't get destroyed when switching Scenes
+        /// </summary>
+        public static T Instance { get; private set; }
+
+        /// <summary>
+        /// Enables DontDestroyOnLoad and checks if there is already a Singleton of this type.
+        /// <para>Add a specific Singleton to the "Script Execution Order" to load it before other Awakes get executed</para>
+        /// </summary>
+        protected virtual void Awake()
+        {
+            if (Instance != null)
+                Destroy(gameObject);
+            else
+                Instance = this as T;
+            
+            DontDestroyOnLoad(gameObject);
+        }
+        
+    }
+}

--- a/Assets/Scripts/Managers/SingletonImmortal.cs.meta
+++ b/Assets/Scripts/Managers/SingletonImmortal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98b00f0325edbd14d8bac0af6e5a5450
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/DeathScene.cs
+++ b/Assets/Scripts/UI/DeathScene.cs
@@ -11,10 +11,18 @@ namespace UI
         
         private void Start()
         {
-            StartCoroutine( FadeOut(2, whitePanel));
-            playerCharacterAnimator.SetBool ("isDead", true);
+            StartCoroutine(FadeOut(2, whitePanel));
+            StartCoroutine(PlayerDying());
         }
 
+        // calling the die animation
+        private IEnumerator PlayerDying()
+        {
+            playerCharacterAnimator.speed = 0.4f;
+            yield return new WaitForSeconds(2);
+            playerCharacterAnimator.SetBool ("die", true);
+        }
+        
         // fade out UI Objects
         private IEnumerator FadeOut(float fadeDuration, Image elementToFade)
         {

--- a/Assets/Scripts/UI/DeathScene.cs
+++ b/Assets/Scripts/UI/DeathScene.cs
@@ -19,7 +19,7 @@ namespace UI
         private IEnumerator PlayerDying()
         {
             playerCharacterAnimator.speed = 0.4f;
-            yield return new WaitForSeconds(2);
+            yield return new WaitForSeconds(1);
             playerCharacterAnimator.SetBool ("die", true);
         }
         

--- a/Assets/Scripts/UI/LoadDeathScene.cs
+++ b/Assets/Scripts/UI/LoadDeathScene.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using Constants;
 using Entity.Player;
+using Managers;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
@@ -24,7 +25,7 @@ namespace UI
         private void LoadScene()
         {
             canvas.gameObject.SetActive(true);
-            StartCoroutine(FadeThenLoad(2.5f, whitePanel));
+            StartCoroutine(FadeThenLoad(1.5f, whitePanel));
         }
 
         // Fades in the white overlay and when finished loads "DeathScene"
@@ -45,17 +46,11 @@ namespace UI
 
             yield return new WaitForSeconds(fadeDuration);
 
+            FadeOutAmbientSound();
             Load();
             PlayerState.OnPlayerDeath -= LoadScene;
         }
-
-        // sets alpha of the overlay back to 0
-        private void ResetPanelAlpha()
-        {
-            whitePanel.color = new Color(1, 1, 1, 0);
-            canvas.gameObject.SetActive(false);
-        }
-
+        
         // loads "DeathScene"
         private void Load()
         {
@@ -66,8 +61,12 @@ namespace UI
         private void SceneLoadCompleted(Scene scene, LoadSceneMode mode)
         {
             if (scene.buildIndex != Consts.Scene.DEATH) return;
-            ResetPanelAlpha();
             SceneManager.sceneLoaded -= SceneLoadCompleted;
+        }
+
+        private void FadeOutAmbientSound()
+        {
+            AudioManager.Instance.FadeOutPlaying(2);
         }
     }
 }


### PR DESCRIPTION
In addition to visual update of the death scene, there is a quickfix in PlayerState to prevent infinite invoking of OnPlayerDeath.

Also i changed the audiomanager while i was at it. It doesn't get destroyed anymore, this is essential since every scene uses it.